### PR TITLE
chore: update CascadeFlow logo assets

### DIFF
--- a/.github/assets/CF_logo_bright.svg
+++ b/.github/assets/CF_logo_bright.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580.99 95.1">
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 563.75 91.76">
   <defs>
     <style>
       .cls-1 {
@@ -13,11 +13,7 @@
       }
 
       .cls-3 {
-        letter-spacing: 0em;
-      }
-
-      .cls-4 {
-        letter-spacing: 0em;
+        letter-spacing: -.01em;
       }
     </style>
   </defs>
@@ -26,5 +22,5 @@
   <path class="cls-2" d="M14.35,77.41c-7.93,0-14.35-6.42-14.35-14.35V29.8h14.35v47.61Z"/>
   <path class="cls-2" d="M28.36,0h34.7c7.93,0,14.35,6.42,14.35,14.35H28.36V0Z"/>
   <path class="cls-2" d="M77.41,14.35c7.93,0,14.35,6.42,14.35,14.35v33.26h-14.35V14.35Z"/>
-  <text class="cls-1" transform="translate(122.84 75.35)"><tspan x="0" y="0">Cascade</tspan><tspan class="cls-4" x="306.11" y="0">fl</tspan><tspan class="cls-3" x="356.57" y="0">ow</tspan></text>
+  <text class="cls-1" transform="translate(117.44 65.1)"><tspan x="0" y="0">cascade</tspan><tspan class="cls-3" x="294.27" y="0">fl</tspan><tspan x="344.73" y="0">ow</tspan></text>
 </svg>

--- a/.github/assets/CF_logo_dark.svg
+++ b/.github/assets/CF_logo_dark.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580.99 95.1">
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 563.75 91.76">
   <defs>
     <style>
       .cls-1 {
@@ -9,11 +9,7 @@
       }
 
       .cls-2 {
-        letter-spacing: 0em;
-      }
-
-      .cls-3 {
-        letter-spacing: 0em;
+        letter-spacing: -.01em;
       }
     </style>
   </defs>
@@ -22,5 +18,5 @@
   <path d="M14.35,77.41c-7.93,0-14.35-6.42-14.35-14.35V29.8h14.35v47.61Z"/>
   <path d="M28.36,0h34.7c7.93,0,14.35,6.42,14.35,14.35H28.36V0Z"/>
   <path d="M77.41,14.35c7.93,0,14.35,6.42,14.35,14.35v33.26h-14.35V14.35Z"/>
-  <text class="cls-1" transform="translate(122.84 75.35)"><tspan x="0" y="0">Cascade</tspan><tspan class="cls-3" x="306.11" y="0">fl</tspan><tspan class="cls-2" x="356.57" y="0">ow</tspan></text>
+  <text class="cls-1" transform="translate(117.44 65.1)"><tspan x="0" y="0">cascade</tspan><tspan class="cls-2" x="294.27" y="0">fl</tspan><tspan x="344.73" y="0">ow</tspan></text>
 </svg>


### PR DESCRIPTION
## Summary
Updated CascadeFlow logo assets with the latest designs.

## Files Updated (2 files)

### 1. 
- **Usage:** Dark mode / bright backgrounds
- **Used in:** README.md, package READMEs
- **Change:** Updated to latest logo design

### 2.   
- **Usage:** Light mode / dark backgrounds
- **Used in:** README.md, package READMEs
- **Change:** Updated to latest logo design

## Impact

✅ **Visual improvement** - Updated branding across all READMEs  
✅ **Theme support maintained** - Still supports light/dark mode  
✅ **Consistent branding** - Same logos across Python and TypeScript packages  
✅ **Immediate effect** - Will display on GitHub as soon as merged

## Affected Files

The logos are displayed in:
- Main `README.md`
- `packages/core/README.md` (TypeScript)
- `packages/integrations/n8n/README.md` (n8n)
- `.github/assets/README.md` (assets documentation)

## Preview

The updated logos will be visible in the README preview above once this PR is opened.

## Type of Change
- [x] 🎨 Design/branding update
- [x] 📦 Assets update

## Checklist
- [x] Logos updated with latest designs
- [x] Both light and dark mode logos updated
- [x] File sizes optimized (SVG format)
- [x] No breaking changes to paths or filenames
- [x] Theme switching still works correctly