### PR TITLE
Migrate npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,37 +172,34 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      # Update npm to v11.5.1+ for OIDC trusted publishing support
+      - name: Update npm to latest
+        run: npm install -g npm@latest
+
       - name: Publish @cascadeflow/core
         continue-on-error: true
         run: |
           cd packages/core
           npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # OIDC authentication - no token needed!
 
       - name: Publish @cascadeflow/ml
         continue-on-error: true
         run: |
           cd packages/ml
           npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @cascadeflow/n8n-nodes-cascadeflow
         continue-on-error: true
         run: |
           cd packages/integrations/n8n
-          pnpm publish --access public --no-git-checks --no-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --access public --provenance
 
-      - name: Publish @cascadeflow/langchain-cascadeflow
+      - name: Publish @cascadeflow/langchain
         continue-on-error: true
         run: |
           cd packages/langchain-cascadeflow
           npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-to-testpypi:
     name: Publish to TestPyPI


### PR DESCRIPTION
## Summary
Migrates npm publishing from classic tokens to OIDC trusted publishing to comply with npm's November 19, 2025 security requirements.

## Changes
- ✅ Removed NODE_AUTH_TOKEN dependency - No more token secrets
- ✅ Added npm CLI update step - Ensures v11.5.1+ for OIDC
- ✅ Standardized all packages to use npm publish with provenance
- ✅ Published @cascadeflow/langchain@0.6.0 (first release)
- 📦 Package: https://www.npmjs.com/package/@cascadeflow/langchain

## Security Benefits
- 🔒 No long-lived tokens in GitHub secrets
- ✅ Automatic provenance attestations
- 🎯 Package-specific permissions
- 📝 Complies with npm Nov 19, 2025 security mandate

## Configuration Required
Each package needs trusted publisher on npmjs.com:
- Organization: lemony-ai
- Repository: cascadeflow
- Workflow: publish.yml
- Environment: npm

Co-Authored-By: Claude <noreply@anthropic.com>