### PR TITLE
fix(langchain-ts): Match TypeScript quality scoring thresholds to Python

### DIFF
--- a/packages/langchain-cascadeflow/src/utils.test.ts
+++ b/packages/langchain-cascadeflow/src/utils.test.ts
@@ -125,24 +125,25 @@ describe('calculateQuality', () => {
     };
 
     const result = calculateQuality(response);
-    // Base 0.6 + length>20 (0.1) + has punctuation (0.05) + starts capital (0.05) + ends punctuation (0.1) = 0.9
-    expect(result).toBeGreaterThanOrEqual(0.7);
-    expect(result).toBeLessThanOrEqual(1.0);
+    // Base 0.4 + has punctuation (0.05) + starts capital (0.05) + ends punctuation (0.05) = 0.55
+    // Text is only 18 chars, so no length bonuses (need >50 and >200)
+    expect(result).toBeGreaterThanOrEqual(0.5);
+    expect(result).toBeLessThanOrEqual(0.6);
   });
 
   it('should calculate quality for complex answer', () => {
     const response = {
       generations: [
         {
-          text: 'Quantum entanglement is a fundamental phenomenon in quantum mechanics where two or more particles become interconnected.',
+          text: 'Quantum entanglement is a fundamental phenomenon in quantum mechanics where two or more particles become interconnected in such a way that the quantum state of each particle cannot be described independently, even when separated by large distances.',
         },
       ],
     };
 
     const result = calculateQuality(response);
-    // Base 0.6 + length>20 (0.1) + length>100 (0.1) + punctuation (0.05) + capital (0.05) + ends (0.1) = 1.0
-    expect(result).toBeGreaterThanOrEqual(0.9);
-    expect(result).toBe(1.0);
+    // Base 0.4 + length>50 (0.1) + length>200 (0.1) + punctuation (0.05) + capital (0.05) + ends (0.05) = 0.75
+    expect(result).toBeGreaterThanOrEqual(0.7);
+    expect(result).toBeLessThanOrEqual(0.8);
   });
 
   it('should penalize hedging phrases', () => {
@@ -155,8 +156,8 @@ describe('calculateQuality', () => {
     };
 
     const result = calculateQuality(response);
-    // Base 0.6 + length>20 (0.1) + punct (0.05) + capital (0.05) + ends (0.1) - hedge (0.1) = 0.8
-    expect(result).toBeLessThanOrEqual(0.8);
+    // Base 0.4 + punct (0.05) + capital (0.05) + ends (0.05) - hedge (0.15) = 0.4
+    expect(result).toBeLessThanOrEqual(0.5);
   });
 
   it('should extract text from message.content', () => {
@@ -171,7 +172,9 @@ describe('calculateQuality', () => {
     };
 
     const result = calculateQuality(response);
-    expect(result).toBeGreaterThan(0.7);
+    // Base 0.4 + punct (0.05) + capital (0.05) + ends (0.05) = 0.55 (text is 48 chars, needs >50 for bonus)
+    expect(result).toBeGreaterThan(0.5);
+    expect(result).toBeLessThan(0.7);
   });
 
   it('should handle logprobs-based confidence (OpenAI)', () => {

--- a/packages/langchain-cascadeflow/src/utils.ts
+++ b/packages/langchain-cascadeflow/src/utils.ts
@@ -106,26 +106,26 @@ export function calculateQuality(response: any): number {
   }
 
   // Check for common quality indicators
-  let score = 0.6; // Base score (increased from 0.5)
+  let score = 0.4; // Base score (lowered from 0.6 to match Python for realistic evaluation)
 
-  // Length bonus (reasonable response)
-  if (text.length > 20) score += 0.1;
-  if (text.length > 100) score += 0.1;
+  // Length bonus (reasonable response) - increased thresholds to match Python
+  if (text.length > 50) score += 0.1;  // Increased from 20
+  if (text.length > 200) score += 0.1; // Increased from 100
 
   // Structure bonus (has punctuation, capitalization)
   if (/[.!?]/.test(text)) score += 0.05;
   if (/^[A-Z]/.test(text)) score += 0.05;
 
-  // Completeness bonus (ends with punctuation)
-  if (/[.!?]$/.test(text.trim())) score += 0.1;
+  // Completeness bonus (ends with punctuation) - reduced to match Python
+  if (/[.!?]$/.test(text.trim())) score += 0.05; // Reduced from 0.1
 
-  // Penalize hedging phrases (but less harshly)
+  // Penalize hedging phrases - increased penalty to match Python
   const hedgingPhrases = [
     'i don\'t know', 'i\'m not sure', 'i cannot', 'i can\'t'
   ];
   const lowerText = text.toLowerCase();
   const hedgeCount = hedgingPhrases.filter(phrase => lowerText.includes(phrase)).length;
-  score -= hedgeCount * 0.1;
+  score -= hedgeCount * 0.15; // Increased from 0.1 to match Python
 
   return Math.max(0.1, Math.min(1, score));
 }

--- a/packages/langchain-cascadeflow/src/wrapper.test.ts
+++ b/packages/langchain-cascadeflow/src/wrapper.test.ts
@@ -114,7 +114,12 @@ describe('CascadeFlow', () => {
 
   describe('Cascade Logic - High Quality Drafter', () => {
     it('should use drafter response when quality is above threshold', async () => {
-      const drafterResponse = createChatResult('The answer is 4.', 14, 8);
+      // Response needs >200 chars to score 0.75 (above 0.7 threshold) with new thresholds
+      const drafterResponse = createChatResult(
+        'The answer to 2+2 is 4. This is a basic arithmetic operation that adds two and two together. When you add the number two to another instance of the number two, the result is four. This fundamental mathematical principle is one of the first concepts taught in elementary arithmetic education.',
+        14,
+        8
+      );
       const verifierResponse = createChatResult('2 + 2 equals 4.', 14, 10);
 
       const drafter = new MockChatModel('gpt-4o-mini', [drafterResponse]);
@@ -130,7 +135,9 @@ describe('CascadeFlow', () => {
       const result = await cascade._generate(messages, {});
 
       // Should use drafter response
-      expect(result.generations[0].text).toBe('The answer is 4.');
+      expect(result.generations[0].text).toBe(
+        'The answer to 2+2 is 4. This is a basic arithmetic operation that adds two and two together. When you add the number two to another instance of the number two, the result is four. This fundamental mathematical principle is one of the first concepts taught in elementary arithmetic education.'
+      );
       expect(drafter.callCount).toBe(1);
       expect(verifier.callCount).toBe(0); // Verifier not called
 
@@ -232,7 +239,12 @@ describe('CascadeFlow', () => {
 
   describe('Cost Tracking', () => {
     it('should calculate costs correctly for accepted drafter', async () => {
-      const drafterResponse = createChatResult('The answer is 4.', 14, 8);
+      // Response needs >200 chars to score 0.75 (above 0.7 threshold) with new thresholds
+      const drafterResponse = createChatResult(
+        'The answer to the question is 4, which is the result of adding 2 plus 2 together. This is a fundamental arithmetic operation that demonstrates the basic principles of addition in mathematics. Understanding addition is essential for more advanced mathematical concepts and practical everyday calculations that we encounter in daily life.',
+        14,
+        8
+      );
 
       const drafter = new MockChatModel('gpt-4o-mini', [drafterResponse]);
       const verifier = new MockChatModel('gpt-4o', []);
@@ -351,8 +363,13 @@ describe('CascadeFlow', () => {
 
   describe('Metadata Injection', () => {
     it('should inject cascade metadata into llmOutput', async () => {
-      const drafterResponse = createChatResult('The answer is correct.', 14, 8);
-      const dummyResponse = createChatResult('Dummy', 14, 8);
+      // Response needs >200 chars to score 0.75 (above 0.7 threshold) with new thresholds
+      const drafterResponse = createChatResult(
+        'The answer provided here is completely correct and demonstrates excellent understanding of the underlying concepts. This response shows a thorough grasp of the subject matter and provides clear, accurate information that addresses the question comprehensively with proper attention to detail and clarity.',
+        14,
+        8
+      );
+      const dummyResponse = createChatResult('Dummy response text here for testing purposes only.', 14, 8);
 
       const drafter = new MockChatModel('gpt-4o-mini', [drafterResponse]);
       const verifier = new MockChatModel('gpt-4o', [dummyResponse]);
@@ -488,8 +505,13 @@ describe('CascadeFlow', () => {
     });
 
     it('should return stats after successful call', async () => {
-      const drafterResponse = createChatResult('The answer is correct.', 14, 8);
-      const dummyResponse = createChatResult('Dummy', 14, 8);
+      // Response needs >200 chars to score 0.75 (above 0.7 threshold) with new thresholds
+      const drafterResponse = createChatResult(
+        'The answer provided is completely correct and demonstrates good understanding of the fundamental concepts involved. This explanation shows careful consideration of the topic and presents information in a clear, well-structured manner that effectively communicates the key points to the reader.',
+        14,
+        8
+      );
+      const dummyResponse = createChatResult('Dummy response for testing purposes only here.', 14, 8);
 
       const drafter = new MockChatModel('gpt-4o-mini', [drafterResponse]);
       const verifier = new MockChatModel('gpt-4o', [dummyResponse]);
@@ -504,14 +526,23 @@ describe('CascadeFlow', () => {
 
       const stats = cascade.getLastCascadeResult();
       expect(stats).toBeDefined();
-      expect(stats!.content).toBe('The answer is correct.');
+      expect(stats!.content).toBe('The answer provided is completely correct and demonstrates good understanding of the fundamental concepts involved. This explanation shows careful consideration of the topic and presents information in a clear, well-structured manner that effectively communicates the key points to the reader.');
       expect(stats!.modelUsed).toBe('drafter');
     });
 
     it('should update stats on each call', async () => {
-      const response1 = createChatResult('The first answer is good.', 14, 8);
-      const response2 = createChatResult('The second answer is better.', 20, 10);
-      const dummyResponse = createChatResult('Dummy', 14, 8);
+      // Responses need >200 chars to score 0.75 (above 0.7 threshold) with new thresholds
+      const response1 = createChatResult(
+        'The first answer provided here is good and shows solid understanding of the key concepts involved in this discussion. This response demonstrates comprehensive knowledge and presents the information clearly with appropriate detail to help readers understand the main points effectively.',
+        14,
+        8
+      );
+      const response2 = createChatResult(
+        'The second answer given here is even better with more detail and thorough explanation of the concepts. This response provides excellent clarity and demonstrates a deep understanding of the subject matter with well-structured reasoning that makes the content accessible to readers.',
+        20,
+        10
+      );
+      const dummyResponse = createChatResult('Dummy response for verification testing only here.', 14, 8);
 
       const drafter = new MockChatModel('gpt-4o-mini', [response1, response2]);
       const verifier = new MockChatModel('gpt-4o', [dummyResponse]);
@@ -525,11 +556,11 @@ describe('CascadeFlow', () => {
 
       await cascade._generate(messages, {});
       const stats1 = cascade.getLastCascadeResult();
-      expect(stats1!.content).toBe('The first answer is good.');
+      expect(stats1!.content).toBe('The first answer provided here is good and shows solid understanding of the key concepts involved in this discussion. This response demonstrates comprehensive knowledge and presents the information clearly with appropriate detail to help readers understand the main points effectively.');
 
       await cascade._generate(messages, {});
       const stats2 = cascade.getLastCascadeResult();
-      expect(stats2!.content).toBe('The second answer is better.');
+      expect(stats2!.content).toBe('The second answer given here is even better with more detail and thorough explanation of the concepts. This response provides excellent clarity and demonstrates a deep understanding of the subject matter with well-structured reasoning that makes the content accessible to readers.');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes inconsistent behavior between TypeScript and Python LangChain integrations where TypeScript was accepting 100% of queries while Python correctly accepted only 50%.

## Problem

TypeScript quality scoring was too generous, causing it to accept all queries instead of properly escalating low-quality responses to the verifier:
- **Before**: TypeScript accepted 100% of queries (18/18 cascaded, 0 escalated)
- **Python**: Correctly accepted 50% of queries (3/6 accepted, 3/6 escalated)
- **Issue**: Simple query "What is 2+2?" should escalate but was being accepted

## Root Cause

TypeScript `calculateQuality()` had much more permissive thresholds than Python:

| Parameter | TypeScript (Before) | Python (Correct) | Difference |
|-----------|---------------------|------------------|------------|
| Base score | 0.6 | 0.4 | +0.2 (50% more) |
| Length threshold 1 | >20 chars | >50 chars | 2.5x easier |
| Length threshold 2 | >100 chars | >200 chars | 2x easier |
| Completeness bonus | +0.1 | +0.05 | 2x more |
| Hedging penalty | -0.1 | -0.15 | Less strict |

## Changes

### 1. Updated TypeScript Quality Scoring (`packages/langchain-cascadeflow/src/utils.ts`)
```typescript
// Before (Too Generous):
let score = 0.6;  // Base score
if (text.length > 20) score += 0.1;
if (text.length > 100) score += 0.1;
if (/[.!?]$/.test(text.trim())) score += 0.1;
score -= hedgeCount * 0.1;

// After (Matches Python):
let score = 0.4;  // Base score (lowered from 0.6)
if (text.length > 50) score += 0.1;   // Increased from 20
if (text.length > 200) score += 0.1;  // Increased from 100
if (/[.!?]$/.test(text.trim())) score += 0.05; // Reduced from 0.1
score -= hedgeCount * 0.15; // Increased from 0.1
```

### 2. Updated Test Mock Responses
- Made mock responses longer (>200 chars) to score above 0.7 threshold
- Updated test expectations to match new realistic scoring
- Fixed 6 failing tests caused by threshold changes

## Verification

### TypeScript Tests ✅
```bash
npm test
# ✓ 62 tests passing (utils.test.ts, helpers.test.ts, wrapper.test.ts)
```

### Python Tests ✅
```bash
python -m pytest cascadeflow/integrations/langchain/tests/ -v
# ✓ 27 tests passing
```

### Examples Verified ✅

**TypeScript basic-usage.ts:**
- "What is 2+2?" → 50% quality → **escalates to verifier** ✅
- Complex question → 75% quality → **accepts drafter** ✅

**Python basic usage:**
- "What is 2+2?" → 50% quality → **escalates to verifier** ✅
- Complex question → 75% quality → **accepts drafter** ✅

**Both implementations now behave identically!**

## Impact

- ✅ TypeScript now matches Python behavior exactly
- ✅ Simple queries correctly escalate when quality is insufficient
- ✅ Complex queries correctly accepted when quality is high
- ✅ All tests passing in both TypeScript (62) and Python (27)
- ✅ Realistic cost/quality tradeoff (50% acceptance for mixed queries)

## Files Changed

- `packages/langchain-cascadeflow/src/utils.ts` - Updated quality thresholds
- `packages/langchain-cascadeflow/src/utils.test.ts` - Updated test expectations
- `packages/langchain-cascadeflow/src/wrapper.test.ts` - Made mock responses longer

## Testing

- [x] All TypeScript tests passing (62/62)
- [x] All Python tests passing (27/27)
- [x] TypeScript basic-usage.ts example verified
- [x] Python basic usage example verified
- [x] Behavior matches between Python and TypeScript