### PR TITLE
fix(langchain): enable PreRouter by default to match Python behavior

### DIFF
--- a/packages/langchain-cascadeflow/src/types.ts
+++ b/packages/langchain-cascadeflow/src/types.ts
@@ -44,7 +44,7 @@ export interface CascadeConfig {
   /**
    * Enable pre-routing based on query complexity
    * When enabled, 'hard' and 'expert' queries skip the drafter and go directly to the verifier
-   * @default false
+   * @default true
    */
   enablePreRouter?: boolean;
 

--- a/packages/langchain-cascadeflow/src/wrapper.ts
+++ b/packages/langchain-cascadeflow/src/wrapper.ts
@@ -57,7 +57,7 @@ export class CascadeFlow extends BaseChatModel {
       enableCostTracking: config.enableCostTracking ?? true,
       costTrackingProvider: config.costTrackingProvider ?? 'langsmith',
       qualityValidator: config.qualityValidator ?? calculateQuality,
-      enablePreRouter: config.enablePreRouter ?? false,
+      enablePreRouter: config.enablePreRouter ?? true,  // Match Python default
       preRouter: config.preRouter,
       cascadeComplexities: config.cascadeComplexities ?? ['trivial', 'simple', 'moderate'],
     };


### PR DESCRIPTION
## Problem

TypeScript LangChain integration had `enablePreRouter: false` by default, which meant:
- ALL queries went through drafter first
- Only quality-based cascading happened (after drafter generated response)
- No pre-analysis to skip drafter for very complex queries

This was inconsistent with Python's `enable_pre_router=True` default.

## Solution

Changed TypeScript default to `enablePreRouter: true` to match Python behavior.

## What This Fixes

✅ **Complex queries analyzed BEFORE sending to drafter**
- HARD/EXPERT complexity queries skip drafter entirely
- Go straight to verifier for very complex queries
- Saves latency by avoiding unnecessary drafter attempts

✅ **Matches Python behavior exactly**
- Python: `enable_pre_router=True` (default)
- TypeScript: `enablePreRouter: true` (now default)
- n8n: `useComplexityRouting: true` (already correct)

## Changes

1. `packages/langchain-cascadeflow/src/wrapper.ts:60`
   - Changed `enablePreRouter ?? false` → `enablePreRouter ?? true`
2. `packages/langchain-cascadeflow/src/types.ts:47`
   - Updated docs from `@default false` → `@default true`

## Testing

- ✅ All 62 TypeScript tests passing
- ✅ n8n integration already has correct default
- ✅ Behavior now consistent across Python and TypeScript

## Related

- Fixes issue discovered after PR #90 (quality threshold fixes)
- Ensures TypeScript and Python integrations behave identically