### PR TITLE
fix: resolve core build and typecheck failures

### DIFF
--- a/cascadeflow/quality/quality.py
+++ b/cascadeflow/quality/quality.py
@@ -719,8 +719,9 @@ class QualityValidator:
             # Only bypass confidence if the tool call looks sane and non-multi-turn.
             is_function_call = alignment_features.get("is_function_call", False)
             valid_function_call = alignment_features.get("valid_function_call_response", False)
-            is_multi_turn = alignment_features.get("is_multi_turn", False)
-            is_multi_turn = is_multi_turn or self._is_multi_turn_prompt(query)
+            is_multi_turn = alignment_features.get(
+                "is_multi_turn", False
+            ) or self._is_multi_turn_prompt(query)
 
             if not is_function_call:
                 is_function_call = self._is_function_call_prompt(query)
@@ -740,8 +741,12 @@ class QualityValidator:
             details["function_call_sane"] = function_call_sane
             details["valid_function_call_response"] = valid_function_call
 
-            all_valid = is_function_call and valid_function_call and function_call_sane
-            if all_valid and not is_multi_turn:
+            if (
+                is_function_call
+                and valid_function_call
+                and function_call_sane
+                and not is_multi_turn
+            ):
                 checks["confidence"] = True  # Allow bypass for simple, sane tool calls
             else:
                 details["function_call_requires_verifier"] = True

--- a/cascadeflow/routing/task_detector.py
+++ b/cascadeflow/routing/task_detector.py
@@ -281,7 +281,7 @@ class TaskDetector:
         # Strategy 4: Count items in newline-separated lists after markers
         # Look for sections like "Available intents:\n- item1\n- item2"
         list_section_pattern = (
-            r"(?:intents?|categories?|labels?|options?|choices?):\s*\n" r"((?:[-*]\s*\w+.*\n)+)"
+            r"(?:intents?|categories?|labels?|options?|choices?):\s*\n((?:[-*]\s*\w+.*\n)+)"
         )
         list_sections = re.findall(list_section_pattern, query, re.IGNORECASE)
         for section in list_sections:
@@ -317,8 +317,9 @@ class TaskDetector:
                     continue
                 elif not re.match(r"^[\w_]+$", line_stripped):
                     # Non-intent content, might end section
-                    end_markers = ("format", "output", "instruction", "respond")
-                    if line_stripped.lower().startswith(end_markers):
+                    if line_stripped.lower().startswith(
+                        ("format", "output", "instruction", "respond")
+                    ):
                         in_list_section = False
 
         count = max(count, len(intent_lines))

--- a/packages/core/src/vercel-ai/__tests__/e2e.test.ts
+++ b/packages/core/src/vercel-ai/__tests__/e2e.test.ts
@@ -45,19 +45,28 @@ const OPENAI_MODEL = process.env.OPENAI_MODEL ?? openAIAdapter.models[0].id;
 const GROQ_MODEL = process.env.GROQ_MODEL ?? groqAdapter.models[1].id;
 const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL ?? anthropicAdapter.models[0].id;
 
-function normalizeUsage(usage?: {
+type RawUsage = {
   prompt_tokens?: number;
   completion_tokens?: number;
   total_tokens?: number;
 } | {
   input_tokens?: number;
   output_tokens?: number;
-}): UsageMetrics {
-  // Use type assertion to handle union type access
-  const u = usage as Record<string, number | undefined> | undefined;
-  const promptTokens = u?.prompt_tokens ?? u?.input_tokens ?? 0;
-  const completionTokens = u?.completion_tokens ?? u?.output_tokens ?? 0;
-  const totalTokens = u?.total_tokens ?? promptTokens + completionTokens;
+};
+
+function normalizeUsage(usage?: RawUsage): UsageMetrics {
+  const normalized = (usage ?? {}) as {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+
+  const promptTokens = normalized.prompt_tokens ?? normalized.input_tokens ?? 0;
+  const completionTokens =
+    normalized.completion_tokens ?? normalized.output_tokens ?? 0;
+  const totalTokens = normalized.total_tokens ?? promptTokens + completionTokens;
 
   return { promptTokens, completionTokens, totalTokens };
 }

--- a/tests/e2e/basic_usage_parity.py
+++ b/tests/e2e/basic_usage_parity.py
@@ -55,7 +55,9 @@ def main() -> int:
         denom = max(py_val, ts_val, 1.0)
         pct_diff = diff / denom
         if pct_diff > tolerance:
-            failures.append({"metric": key, "python": py_val, "typescript": ts_val, "diff": pct_diff})
+            failures.append(
+                {"metric": key, "python": py_val, "typescript": ts_val, "diff": pct_diff}
+            )
 
     result = {
         "python": py_stats,


### PR DESCRIPTION
## Summary\n- fix optional @cascadeflow/ml import typing for builds\n- normalize vercel-ai usage shape in tests\n- black-format python files touched\n\n## Testing\n- python3 -m black --check cascadeflow tests examples\n- pnpm --filter @cascadeflow/ml build\n- pnpm --filter @cascadeflow/core build\n- pnpm --filter @cascadeflow/core typecheck\n- pnpm --filter @cascadeflow/core test\n- python3 -m pytest