### PR TITLE
fix(benchmarks): repair MMLU runner + use GSM8K config

### DIFF
--- a/tests/benchmarks/mmlu/__init__.py
+++ b/tests/benchmarks/mmlu/__init__.py
@@ -1,0 +1,9 @@
+"""MMLU benchmark package.
+
+Allows importing `MMLUBenchmark` via:
+`from tests.benchmarks.mmlu import MMLUBenchmark`.
+"""
+
+from .mmlu import MMLUBenchmark
+
+__all__ = ["MMLUBenchmark"]

--- a/tests/benchmarks/run_benchmarks.py
+++ b/tests/benchmarks/run_benchmarks.py
@@ -265,7 +265,8 @@ async def run_all_benchmarks(
         print("Running GSM8K Benchmark...")
         print("=" * 80)
         try:
-            gsm8k_result = await run_gsm8k_benchmark(config, gsm8k_samples)
+            gsm8k_config = BenchmarkConfig.for_gsm8k(mode)
+            gsm8k_result = await run_gsm8k_benchmark(gsm8k_config, gsm8k_samples)
             results["benchmarks"].append(gsm8k_result)
             print(
                 f"\nGSM8K Complete: {gsm8k_result['accuracy']:.1f}% accuracy, {gsm8k_result['cost_reduction_pct']:.1f}% cost reduction"


### PR DESCRIPTION
- Fixes MMLU benchmark imports and updates CascadeAgent construction to current API
- Adds tests/benchmarks/mmlu/__init__.py for stable imports
- Ensures GSM8K uses BenchmarkConfig.for_gsm8k like MMLU/MT-Bench

Local: ran black + ruff and executed benchmark runs with .env (quick suite + MMLU-only).