### PR TITLE
chore(testing): extended E2E benchmark session runner

### DIFF
--- a/docs/guides/extended-testing.md
+++ b/docs/guides/extended-testing.md
@@ -1,0 +1,108 @@
+# Extended Testing And Benchmarking (Real APIs)
+
+This guide describes how to run an extended end-to-end (E2E) validation session for cascadeflow using **real provider APIs**.
+
+Goals:
+- Validate correctness, routing logic, and cost optimization in the ways developers actually use cascadeflow:
+  - Apps (Next.js API routes, Vercel AI SDK `useChat`)
+  - Agents (tools, multi-turn, structured outputs)
+  - Routers/proxies (OpenAI-compatible HTTP, existing SDKs)
+- Produce numbers you can share: **accuracy**, **drafter acceptance**, **cost reduction**, latency.
+
+## Setup
+
+1. Load provider keys (repo root `.env`):
+```bash
+set -a && source .env && set +a
+```
+
+2. Install deps:
+```bash
+pnpm install
+python3 -m pip install -r requirements-dev.txt
+```
+
+## What We Measure
+
+- **Accuracy**: dataset-specific correctness (e.g. GSM8K exact match, MMLU multiple-choice, tool-call correctness).
+- **Drafter acceptance**: how often the cheap model is accepted without escalation.
+- **Cost reduction**: savings vs a verifier-only baseline.
+- **Latency**: end-to-end time per request (where available).
+
+## Benchmark Coverage Map
+
+Python benchmark suite (see `tests/benchmarks/`):
+- `run_benchmarks.py`: GSM8K + MMLU + MT-Bench (cost reduction + quality retention targets).
+- `run_all.py`: broad coverage:
+  - HumanEval (code)
+  - GSM8K (math)
+  - MT-Bench (multi-turn)
+  - TruthfulQA (factual)
+  - Banking77 (classification)
+  - Customer support (real-world Q&A)
+  - BFCL agentic tool calling (multi-turn + dependencies)
+  - Tool calling (single + multi-turn tool selection correctness)
+  - Agentic multi-agent (router + tool call correctness)
+  - Provider comparison (quality engine consistency across providers)
+
+TypeScript coverage (monorepo tests):
+- `pnpm test`: builds + tests all TS packages and the Next.js `useChat` example.
+- Vercel AI SDK handler E2E tests:
+  - `packages/core/src/vercel-ai/__tests__/e2e.test.ts`
+  - `packages/core/src/__tests__/vercel-ai-chat-handler.e2e.test.ts`
+- Optional real API smoke:
+  - `pnpm -C packages/core run real-api:smoke`
+
+## Recommended Sessions
+
+### 1) Smoke (Fast Signal, Low Spend)
+
+One-command runner (writes logs/results under `benchmark_results/sessions/`):
+```bash
+set -a && source .env && set +a
+./scripts/extended-e2e-session.sh smoke
+```
+
+Manual steps:
+```bash
+pnpm test
+python3 -m pytest
+
+pnpm -C packages/core exec vitest run \
+  src/vercel-ai/__tests__/e2e.test.ts \
+  src/__tests__/vercel-ai-chat-handler.e2e.test.ts
+
+python3 tests/benchmarks/run_benchmarks.py --quick --output benchmark_results/e2e_quick.json || true
+python3 -m tests.benchmarks.run_all --profile smoke --output-dir benchmark_results/smoke
+```
+
+### 2) Standard (Shareable Numbers)
+
+```bash
+set -a && source .env && set +a
+./scripts/extended-e2e-session.sh standard
+```
+
+### 3) Overnight (Stress + Agentic)
+
+```bash
+python3 -m tests.benchmarks.run_all --profile overnight --output-dir benchmark_results/overnight
+```
+
+## Developer DX Validation (Out Of The Box)
+
+Minimal “does it work for users tomorrow” checks:
+1. `docs/guides/integrate_fast.md` paths:
+   - Vercel AI SDK `useChat` drop-in: build the example `examples/vercel-ai-nextjs/`
+   - Proxy: validate OpenAI-compatible endpoint behavior (see `docs/guides/proxy.md`)
+2. Agent tools:
+   - Tool-call generation correctness: `python3 -m tests.benchmarks.tool_calls`
+   - Multi-turn tool history: `python3 -m tests.benchmarks.tool_calls_agentic`
+
+## Notes / Current Limits
+
+- Tool-call *generation* is benchmarked heavily.
+- Full tool *execution loops* depend on the integration path:
+  - Streaming tool execution exists via the streaming tool manager.
+  - Non-streaming multi-step tool execution is supported for direct routing; cascade tool paths currently focus on tool-call correctness and verification.
+

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
     "typecheck:examples": "tsc --noEmit -p examples/nodejs/tsconfig.json",
+    "real-api:smoke": "tsx scripts/real-api-smoke.ts",
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
     "clean": "rm -rf dist"

--- a/packages/core/scripts/real-api-smoke.ts
+++ b/packages/core/scripts/real-api-smoke.ts
@@ -1,0 +1,116 @@
+/* Real API smoke checks (developer-run).
+ *
+ * Runs a small set of calls against configured providers to validate:
+ * - basic text completion
+ * - tool-call generation + tool execution loop (direct tool loop)
+ * - cost/acceptance fields are populated
+ *
+ * Usage (from repo root):
+ *   set -a && source .env && set +a
+ *   pnpm -C packages/core run real-api:smoke
+ */
+
+import { CascadeAgent } from '../src/index.ts';
+import type { Tool } from '../src/types.ts';
+
+type Env = Record<string, string | undefined>;
+
+function requireAny(env: Env, keys: string[]): void {
+  if (!keys.some((k) => Boolean(env[k]))) {
+    throw new Error(`Missing API keys: expected at least one of: ${keys.join(', ')}`);
+  }
+}
+
+const env = process.env as Env;
+requireAny(env, ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY']);
+
+const getWeatherTool: Tool = {
+  type: 'function',
+  function: {
+    name: 'get_weather',
+    description: 'Get the weather for a location.',
+    parameters: {
+      type: 'object',
+      properties: {
+        location: { type: 'string' },
+      },
+      required: ['location'],
+    },
+  },
+};
+
+async function main(): Promise<void> {
+  const openaiKey = env.OPENAI_API_KEY;
+  const anthropicKey = env.ANTHROPIC_API_KEY;
+
+  if (openaiKey) {
+    const agent = new CascadeAgent({
+      models: [
+        { name: 'gpt-4o-mini', provider: 'openai', cost: 0.00015, apiKey: openaiKey },
+        { name: 'gpt-4o', provider: 'openai', cost: 0.00625, apiKey: openaiKey },
+      ],
+    });
+
+    const r1 = await agent.run('Return exactly: OK');
+    if (!r1.content || !r1.content.includes('OK')) {
+      throw new Error(`OpenAI smoke failed: unexpected content: ${JSON.stringify(r1.content)}`);
+    }
+
+    // Tool loop: direct path only (keeps this deterministic).
+    const r2 = await agent.run("Call get_weather for location 'Paris'. Then respond with the result.", {
+      tools: [getWeatherTool],
+      forceDirect: true,
+      maxSteps: 3,
+      toolExecutor: async (call) => {
+        const name = call.function?.name ?? call.name;
+        if (name !== 'get_weather') return { ok: false, error: 'unknown_tool' };
+        return { location: 'Paris', forecast: 'sunny' };
+      },
+    });
+    if (!r2.content || !/sunny/i.test(r2.content)) {
+      throw new Error(`OpenAI tool-loop smoke failed: content=${JSON.stringify(r2.content)}`);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          provider: 'openai',
+          text: { accepted: r1.draftAccepted, model: r1.modelUsed, cost: r1.totalCost },
+          toolLoop: { accepted: r2.draftAccepted, model: r2.modelUsed, cost: r2.totalCost },
+        },
+        null,
+        2
+      )
+    );
+  }
+
+  if (anthropicKey) {
+    const agent = new CascadeAgent({
+      models: [
+        { name: 'claude-haiku-4-5-20251001', provider: 'anthropic', cost: 0.003, apiKey: anthropicKey },
+        { name: 'claude-opus-4-5-20251101', provider: 'anthropic', cost: 0.045, apiKey: anthropicKey },
+      ],
+    });
+
+    const r1 = await agent.run('Return exactly: OK');
+    if (!r1.content || !r1.content.includes('OK')) {
+      throw new Error(`Anthropic smoke failed: unexpected content: ${JSON.stringify(r1.content)}`);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          provider: 'anthropic',
+          text: { accepted: r1.draftAccepted, model: r1.modelUsed, cost: r1.totalCost },
+        },
+        null,
+        2
+      )
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(String(err?.stack ?? err));
+  process.exit(1);
+});

--- a/scripts/extended-e2e-session.sh
+++ b/scripts/extended-e2e-session.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extended E2E validation session (real APIs).
+#
+# Usage:
+#   set -a && source .env && set +a
+#   ./scripts/extended-e2e-session.sh smoke
+#
+# Profiles: smoke | standard | overnight | full
+
+PROFILE="${1:-smoke}"
+TS="$(date +%Y%m%d_%H%M%S)"
+OUTDIR="benchmark_results/sessions/${TS}_${PROFILE}"
+
+mkdir -p "${OUTDIR}"
+
+{
+  echo "timestamp=${TS}"
+  echo "profile=${PROFILE}"
+  echo "git_sha=$(git rev-parse HEAD)"
+  echo "git_branch=$(git rev-parse --abbrev-ref HEAD)"
+  echo "node=$(node -v 2>/dev/null || true)"
+  echo "pnpm=$(pnpm -v 2>/dev/null || true)"
+  echo "python=$(python3 -V 2>/dev/null || true)"
+} >"${OUTDIR}/meta.txt"
+
+echo "Output: ${OUTDIR}"
+
+echo
+echo "== TS + Python Unit/Integration Tests =="
+pnpm test 2>&1 | tee "${OUTDIR}/pnpm_test.log"
+python3 -m pytest 2>&1 | tee "${OUTDIR}/pytest.log"
+
+echo
+echo "== Vercel AI Handler E2E (TS) =="
+pnpm -C packages/core exec vitest run \
+  src/vercel-ai/__tests__/e2e.test.ts \
+  src/__tests__/vercel-ai-chat-handler.e2e.test.ts 2>&1 | tee "${OUTDIR}/vercel_ai_e2e_vitest.log"
+
+echo
+echo "== TS Real API Smoke (optional) =="
+pnpm -C packages/core run real-api:smoke 2>&1 | tee "${OUTDIR}/ts_real_api_smoke.log" || true
+
+echo
+echo "== Python Benchmarks (triad) =="
+python3 tests/benchmarks/run_benchmarks.py \
+  $([[ "${PROFILE}" == "smoke" ]] && echo "--quick" || true) \
+  --output "${OUTDIR}/triad.json" 2>&1 | tee "${OUTDIR}/triad.log" || true
+
+echo
+echo "== Python Benchmarks (broad suite) =="
+python3 -m tests.benchmarks.run_all \
+  --profile "${PROFILE}" \
+  --output-dir "${OUTDIR}/run_all" 2>&1 | tee "${OUTDIR}/run_all.log"
+
+echo
+echo "Completed. Results in: ${OUTDIR}"
+

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -8,6 +8,10 @@ Professional benchmarks to validate CascadeFlow performance across real-world us
 2. **Bitext Customer Support** - Customer service Q&A (27,000+ examples)
 3. **Banking77** - Banking intent classification (13,000+ examples)
 4. **GSM8K** - Grade school math reasoning (8,500+ problems)
+5. **MT-Bench** - Multi-turn chat quality / routing behavior (sampled)
+6. **TruthfulQA** - Factual correctness (sampled)
+7. **Tool Calling** - Structured tool selection correctness (single + multi-turn)
+8. **BFCL Agentic** - Agentic/multi-turn tool-calling patterns (dependencies, chaining)
 
 #### Metrics
 
@@ -20,14 +24,14 @@ Each benchmark measures:
 #### Running Benchmarks
 
 ```bash
-# Run a single benchmark
-python -m benchmarks.datasets.humaneval
+# Load API keys (repo root .env)
+set -a && source .env && set +a
 
-# Run all benchmarks
-python -m benchmarks.run_all
+# Run quick triad suite (GSM8K + MMLU + MT-Bench)
+python3 tests/benchmarks/run_benchmarks.py --quick --output benchmark_results/e2e_quick.json || true
 
-# View results
-ls benchmarks/results/
+# Run broad suite (HumanEval, GSM8K, MT-Bench, TruthfulQA, Banking77, tool calling, etc.)
+python3 -m tests.benchmarks.run_all --profile smoke --output-dir benchmark_results/smoke
 ```
 
 #### Output
@@ -39,15 +43,19 @@ ls benchmarks/results/
 #### Structure
 
 ```
-benchmarks/
-├── base.py          # Abstract benchmark class
-├── metrics.py       # Cost/latency/quality calculations
-├── reporter.py      # Report generation
-├── humaneval.py     # Code generation benchmark
-├── customer_support.py  # Customer service Q&A
-├── banking77.py     # Banking intent classification
-├── gsm8k.py         # Math reasoning
-└── results/         # Output directory
+tests/benchmarks/
+├── base.py              # Benchmark base class + summary metrics
+├── run_benchmarks.py    # GSM8K + MMLU + MT-Bench runner (targets)
+├── run_all.py           # Broad suite runner (reports to benchmark_results/)
+├── humaneval/           # HumanEval benchmark implementation
+├── gsm8k/               # GSM8K benchmark implementation
+├── mmlu/                # MMLU benchmark implementation
+├── mtbench/             # MT-Bench benchmark implementation
+├── truthfulqa.py        # TruthfulQA benchmark implementation
+├── banking77_benchmark.py
+├── customer_support.py
+├── tool_calls.py
+└── tool_calls_agentic.py
 ```
 
 All benchmarks extend the `Benchmark` base class.

--- a/tests/benchmarks/agentic_multi_agent.py
+++ b/tests/benchmarks/agentic_multi_agent.py
@@ -1,0 +1,412 @@
+"""Agentic Multi-Agent Benchmark (Routing + Tool Calling, Real APIs).
+
+This benchmark is designed to reflect how developers build agentic systems:
+- A router/planner decides which sub-agent should handle the request.
+- The chosen sub-agent emits structured tool calls (optionally multi-turn).
+
+It reports:
+- Correctness (router decision + tool-call correctness)
+- Drafter acceptance rate (across both calls per task)
+- Cost reduction vs a verifier-only baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from cascadeflow import CascadeAgent, ModelConfig
+
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather for a location and date.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "City name"},
+                "date": {"type": "string", "description": "Date or day"},
+            },
+            "required": ["location"],
+        },
+    },
+}
+
+CURRENCY_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "convert_currency",
+        "description": "Convert an amount between currencies.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "amount": {"type": "number"},
+                "from_currency": {"type": "string"},
+                "to_currency": {"type": "string"},
+            },
+            "required": ["amount", "from_currency", "to_currency"],
+        },
+    },
+}
+
+ORDER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "lookup_order",
+        "description": "Lookup order status by order ID.",
+        "parameters": {
+            "type": "object",
+            "properties": {"order_id": {"type": "string"}},
+            "required": ["order_id"],
+        },
+    },
+}
+
+UPDATE_ORDER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "update_order_status",
+        "description": "Update an order status by order ID.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "order_id": {"type": "string"},
+                "status": {"type": "string"},
+            },
+            "required": ["order_id", "status"],
+        },
+    },
+}
+
+
+@dataclass
+class MultiAgentCase:
+    case_id: str
+    query: str
+    expected_route: str  # weather | currency | orders
+    expected_tool: str
+    expected_params: dict[str, Any]
+    messages: Optional[list[dict[str, Any]]] = None
+
+
+CASES: list[MultiAgentCase] = [
+    MultiAgentCase(
+        case_id="MA/WEATHER/PARIS",
+        query="What's the weather in Paris?",
+        expected_route="weather",
+        expected_tool="get_weather",
+        expected_params={"location": "paris"},
+    ),
+    MultiAgentCase(
+        case_id="MA/WEATHER/MULTITURN",
+        query="And tomorrow?",
+        expected_route="weather",
+        expected_tool="get_weather",
+        expected_params={"location": "berlin"},
+        messages=[
+            {"role": "user", "content": "What's the weather in Berlin?"},
+            {"role": "assistant", "content": "Let me check that for you."},
+            {"role": "user", "content": "And tomorrow?"},
+        ],
+    ),
+    MultiAgentCase(
+        case_id="MA/CURRENCY/USD_EUR",
+        query="Convert 10 USD to EUR.",
+        expected_route="currency",
+        expected_tool="convert_currency",
+        expected_params={"amount": 10, "from_currency": "USD", "to_currency": "EUR"},
+    ),
+    MultiAgentCase(
+        case_id="MA/CURRENCY/MULTITURN",
+        query="Actually convert 150 GBP to USD.",
+        expected_route="currency",
+        expected_tool="convert_currency",
+        expected_params={"amount": 150, "from_currency": "GBP", "to_currency": "USD"},
+        messages=[
+            {"role": "user", "content": "Convert 100 GBP to USD."},
+            {"role": "assistant", "content": "Sure, I can help with that."},
+            {"role": "user", "content": "Actually convert 150 GBP to USD."},
+        ],
+    ),
+    MultiAgentCase(
+        case_id="MA/ORDER/LOOKUP",
+        query="Track order #12345.",
+        expected_route="orders",
+        expected_tool="lookup_order",
+        expected_params={"order_id": "12345"},
+    ),
+    MultiAgentCase(
+        case_id="MA/ORDER/UPDATE_MULTITURN",
+        query="Update it to shipped.",
+        expected_route="orders",
+        expected_tool="update_order_status",
+        expected_params={"order_id": "12345", "status": "shipped"},
+        messages=[
+            {"role": "user", "content": "Track order #12345."},
+            {"role": "assistant", "content": "I can help with that."},
+            {"role": "user", "content": "Update it to shipped."},
+        ],
+    ),
+]
+
+
+ROUTER_PROMPT = """You are a router for an agent system.
+
+Pick which specialist should handle the user request.
+
+Return JSON ONLY:
+{"route": "weather" | "currency" | "orders", "reason": "short"}
+"""
+
+
+def _extract_route(text: str) -> Optional[str]:
+    try:
+        obj = json.loads(text)
+        route = obj.get("route")
+        if isinstance(route, str):
+            route = route.strip().lower()
+            if route in {"weather", "currency", "orders"}:
+                return route
+    except Exception:
+        pass
+
+    # Tolerant fallback: look for route-like tokens.
+    m = re.search(r"\b(weather|currency|orders)\b", text.lower())
+    return m.group(1) if m else None
+
+
+def _tool_call_matches(
+    tool_calls: list[dict[str, Any]],
+    expected_tool: str,
+    expected_params: dict[str, Any],
+) -> bool:
+    for tool_call in tool_calls:
+        name = (
+            tool_call.get("name")
+            or tool_call.get("tool")
+            or (tool_call.get("function") or {}).get("name")
+        )
+        args = (
+            tool_call.get("arguments")
+            or tool_call.get("args")
+            or tool_call.get("parameters")
+            or (tool_call.get("function") or {}).get("arguments")
+        )
+
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                args = {}
+        if not isinstance(args, dict):
+            args = {}
+
+        if name != expected_tool:
+            continue
+
+        for key, expected_value in expected_params.items():
+            if key not in args:
+                return False
+            actual_value = args.get(key)
+            if expected_value is None:
+                continue
+            if isinstance(expected_value, (int, float)):
+                try:
+                    if float(actual_value) != float(expected_value):
+                        return False
+                except (TypeError, ValueError):
+                    return False
+            else:
+                if str(expected_value).lower() not in str(actual_value).lower():
+                    return False
+
+        return True
+
+    return False
+
+
+async def run_agentic_multi_agent_benchmark(
+    *,
+    drafter_model: str = "claude-haiku-4-5-20251001",
+    verifier_model: str = "claude-opus-4-5-20251101",
+    quality_threshold: float = 0.7,
+    max_tasks: int = 6,
+    verbose: bool = True,
+) -> dict[str, Any]:
+    cases = CASES[:max_tasks]
+
+    router = CascadeAgent(
+        models=[
+            ModelConfig(name=drafter_model, provider="anthropic", cost=0.003),
+            ModelConfig(name=verifier_model, provider="anthropic", cost=0.045),
+        ],
+        quality={"threshold": quality_threshold},
+    )
+
+    tool_agent = CascadeAgent(
+        models=[
+            ModelConfig(name=drafter_model, provider="anthropic", cost=0.003),
+            ModelConfig(name=verifier_model, provider="anthropic", cost=0.045),
+        ],
+        quality={"threshold": quality_threshold},
+    )
+
+    tools = [WEATHER_TOOL, CURRENCY_TOOL, ORDER_TOOL, UPDATE_ORDER_TOOL]
+
+    total_cost = 0.0
+    total_baseline = 0.0
+    accepted_steps = 0
+    total_steps = 0
+    correct_router = 0
+    correct_tool = 0
+    correct_both = 0
+    latencies: list[float] = []
+
+    per_case: list[dict[str, Any]] = []
+
+    print("=" * 70)
+    print("AGENTIC MULTI-AGENT (ROUTER + TOOL CALLING)")
+    print("=" * 70)
+    print(f"Tasks: {len(cases)} | Drafter: {drafter_model} | Verifier: {verifier_model}")
+    print()
+
+    for idx, case in enumerate(cases, 1):
+        case_start = time.time()
+
+        # Step 1: router chooses route
+        router_messages = [{"role": "system", "content": ROUTER_PROMPT}]
+        router_messages.append({"role": "user", "content": case.query})
+        router_res = await router.run(router_messages, max_tokens=80, temperature=0.0)
+        route = _extract_route(router_res.content)
+        router_ok = route == case.expected_route
+
+        total_steps += 1
+        accepted_steps += 1 if router_res.draft_accepted else 0
+
+        # Step 2: tool agent emits tool call (using multi-turn messages when provided)
+        tool_messages = case.messages or [{"role": "user", "content": case.query}]
+        tool_res = await tool_agent.run(
+            tool_messages,
+            max_tokens=200,
+            temperature=0.0,
+            tools=tools,
+            tool_choice="auto",
+        )
+        tool_calls = tool_res.tool_calls or []
+        tool_ok = _tool_call_matches(tool_calls, case.expected_tool, case.expected_params)
+
+        total_steps += 1
+        accepted_steps += 1 if tool_res.draft_accepted else 0
+
+        correct_router += 1 if router_ok else 0
+        correct_tool += 1 if tool_ok else 0
+        both_ok = router_ok and tool_ok
+        correct_both += 1 if both_ok else 0
+
+        # Costs (prefer cascadeflow's own baseline/cost semantics when available)
+        for r in (router_res, tool_res):
+            total_cost += float(r.total_cost or 0.0)
+            baseline = r.baseline_cost
+            if baseline is not None:
+                total_baseline += float(baseline)
+
+        latency_ms = (time.time() - case_start) * 1000
+        latencies.append(latency_ms)
+
+        row = {
+            "case_id": case.case_id,
+            "router_route": route,
+            "expected_route": case.expected_route,
+            "router_ok": router_ok,
+            "expected_tool": case.expected_tool,
+            "tool_ok": tool_ok,
+            "draft_router": bool(router_res.draft_accepted),
+            "draft_tool": bool(tool_res.draft_accepted),
+            "latency_ms": latency_ms,
+            "router_cost": float(router_res.total_cost or 0.0),
+            "tool_cost": float(tool_res.total_cost or 0.0),
+        }
+        per_case.append(row)
+
+        if verbose:
+            status = "✓" if both_ok else "✗"
+            print(
+                f"[{idx}/{len(cases)}] {case.case_id}: {status} "
+                f"router={route or '∅'} tool_calls={len(tool_calls)} "
+                f"draft=[{'D' if router_res.draft_accepted else 'V'},{'D' if tool_res.draft_accepted else 'V'}] "
+                f"${row['router_cost']+row['tool_cost']:.4f} {latency_ms:.0f}ms"
+            )
+
+    accuracy = (correct_both / len(cases)) if cases else 0.0
+    router_acc = (correct_router / len(cases)) if cases else 0.0
+    tool_acc = (correct_tool / len(cases)) if cases else 0.0
+
+    acceptance = (accepted_steps / total_steps) if total_steps else 0.0
+
+    savings = max(0.0, total_baseline - total_cost) if total_baseline > 0 else 0.0
+    savings_pct = ((savings / total_baseline) * 100.0) if total_baseline > 0 else 0.0
+
+    avg_latency_ms = (sum(latencies) / len(latencies)) if latencies else 0.0
+
+    summary = {
+        "dataset_name": f"Agentic-MultiAgent-{len(cases)}",
+        "total_tasks": len(cases),
+        "accuracy": accuracy,
+        "router_accuracy": router_acc,
+        "tool_accuracy": tool_acc,
+        "draft_acceptance": acceptance,
+        "total_cost": total_cost,
+        "baseline_cost": total_baseline,
+        "total_savings": savings,
+        "cost_reduction_pct": savings_pct,
+        "avg_latency_ms": avg_latency_ms,
+        "results": per_case,
+    }
+
+    print()
+    print("Summary:")
+    print(f"  Accuracy (router+tool): {accuracy*100:.1f}%")
+    print(f"  Router accuracy:        {router_acc*100:.1f}%")
+    print(f"  Tool accuracy:          {tool_acc*100:.1f}%")
+    print(f"  Drafter acceptance:     {acceptance*100:.1f}% (steps={total_steps})")
+    if total_baseline > 0:
+        print(f"  Cost reduction:         {savings_pct:.1f}%")
+        print(f"  Total cost:             ${total_cost:.6f} (baseline ${total_baseline:.6f})")
+    else:
+        print(f"  Total cost:             ${total_cost:.6f} (baseline unavailable)")
+
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Agentic multi-agent benchmark (router + tool calls)"
+    )
+    parser.add_argument("--tasks", type=int, default=6, help="Number of tasks to run")
+    parser.add_argument("--drafter", type=str, default="claude-haiku-4-5-20251001")
+    parser.add_argument("--verifier", type=str, default="claude-opus-4-5-20251101")
+    parser.add_argument("--threshold", type=float, default=0.7)
+    parser.add_argument("--quiet", action="store_true", help="Reduce per-task output")
+
+    args = parser.parse_args()
+
+    asyncio.run(
+        run_agentic_multi_agent_benchmark(
+            drafter_model=args.drafter,
+            verifier_model=args.verifier,
+            quality_threshold=args.threshold,
+            max_tasks=args.tasks,
+            verbose=not args.quiet,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/run_benchmarks.py
+++ b/tests/benchmarks/run_benchmarks.py
@@ -454,9 +454,9 @@ Examples:
 
     args = parser.parse_args()
 
-    # Check API key
-    if not os.getenv("OPENAI_API_KEY"):
-        print("Error: OPENAI_API_KEY environment variable not set")
+    # Check API keys (benchmarks may use OpenAI and/or Anthropic depending on config)
+    if not os.getenv("OPENAI_API_KEY") and not os.getenv("ANTHROPIC_API_KEY"):
+        print("Error: No provider API key found (set OPENAI_API_KEY and/or ANTHROPIC_API_KEY)")
         sys.exit(1)
 
     # Run benchmarks


### PR DESCRIPTION
Adds an extended real-API testing/benchmarking session setup:

- New guide: docs/guides/extended-testing.md
- Updated benchmark README with correct commands
- tests/benchmarks/run_all.py: adds --profile presets (smoke/standard/overnight/full), optional provider comparison, and limits BFCL agentic task count
- New benchmark: tests/benchmarks/agentic_multi_agent.py (router + tool-calling correctness + cost reduction)
- One-command session runner: scripts/extended-e2e-session.sh (logs + JSON artifacts)
- TypeScript real API smoke: pnpm -C packages/core run real-api:smoke
