### PR TITLE
fix(openclaw): parser-safe streaming final chunks across adapters

### DIFF
--- a/tests/test_openclaw_openai_server_streaming.py
+++ b/tests/test_openclaw_openai_server_streaming.py
@@ -72,5 +72,11 @@ def test_openclaw_openai_server_stream_includes_role_and_final_finish_reason() -
         last = chunks[-1]["choices"][0]
         assert last["delta"] == {}
         assert last["finish_reason"] == "stop"
+        assert last["message"]["role"] == "assistant"
+        assert last["message"]["content"] == "Hi!"
+
+        usage = chunks[-1].get("usage", {})
+        assert usage.get("total_tokens", 0) >= 1
+        assert usage.get("totalTokens", 0) >= 1
     finally:
         server.stop()

--- a/tests/test_proxy_agent_mode.py
+++ b/tests/test_proxy_agent_mode.py
@@ -149,6 +149,19 @@ def test_openai_agent_streaming(agent_proxy):
 
     assert any(line.startswith("data: ") for line in lines)
     assert lines[-1] == "data: [DONE]"
+    json_chunks = []
+    for line in lines:
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :]
+        if payload == "[DONE]":
+            continue
+        json_chunks.append(json.loads(payload))
+    assert json_chunks
+    assert json_chunks[0]["choices"][0]["delta"]["role"] == "assistant"
+    assert json_chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    assert json_chunks[-1]["usage"]["total_tokens"] >= 1
+    assert json_chunks[-1]["usage"]["totalTokens"] >= 1
 
 
 def test_anthropic_agent_streaming(agent_proxy):


### PR DESCRIPTION
## Summary
- fix OpenClaw-facing OpenAI streaming responses so strict parsers do not drop assistant output
- emit explicit final stream chunk with `message.role/content`, `finish_reason`, and usage in both snake_case + camelCase
- apply the same compatibility behavior to both OpenClaw native server and proxy streaming paths
- normalize non-stream usage fields with camelCase aliases for OpenAI-compatible clients

## Why
OpenClaw clients can run in OpenAI-compatible streaming mode with `stream: true` hardcoded. Some parsers expect the final chunk to include assistant message content and/or camelCase usage fields. Without that, responses can appear as empty (`content: []`, `usage.totalTokens: 0`) despite valid generation.

## Validation
- `python3 -m ruff check cascadeflow/integrations/openclaw/openai_server.py cascadeflow/proxy/server.py tests/test_openclaw_openai_server_streaming.py tests/test_proxy_agent_mode.py`
- `python3 -m black --check cascadeflow/integrations/openclaw/openai_server.py cascadeflow/proxy/server.py tests/test_openclaw_openai_server_streaming.py tests/test_proxy_agent_mode.py`
- `python3 -m pytest -q tests/test_openclaw_openai_server_streaming.py tests/test_proxy_agent_mode.py`
- `python3 -m pytest -q tests/test_proxy_server.py`
- `python3 -m pytest -q tests/test_openai.py tests/test_tool_calling.py`
