### PR TITLE
test(openclaw): align final streaming delta assertion

### DIFF
--- a/tests/test_openclaw_openai_server_streaming.py
+++ b/tests/test_openclaw_openai_server_streaming.py
@@ -70,7 +70,7 @@ def test_openclaw_openai_server_stream_includes_role_and_final_finish_reason() -
             assert choice["finish_reason"] is None
 
         last = chunks[-1]["choices"][0]
-        assert last["delta"] == {}
+        assert last["delta"].get("content") == "Hi!"
         assert last["finish_reason"] == "stop"
         assert last["message"]["role"] == "assistant"
         assert last["message"]["content"] == "Hi!"


### PR DESCRIPTION
## Summary
- fix stale assertion in `tests/test_openclaw_openai_server_streaming.py`
- final stream chunk now intentionally includes `delta.content`, so the test now validates that expected content

## Why
Recent OpenClaw streaming fixes changed the final chunk contract. Runtime behavior is correct, but CI failed because the test still expected `last["delta"] == {}`.

## Validation
- `python3 -m pytest -q tests/test_openclaw_openai_server_streaming.py tests/test_proxy_agent_mode.py`
