### PR TITLE
fix(openclaw): handle tool text streams and avoid mixed cascade output

### DIFF
--- a/cascadeflow/integrations/openclaw/openai_server.py
+++ b/cascadeflow/integrations/openclaw/openai_server.py
@@ -546,7 +546,7 @@ class OpenAIRequestHandler(BaseHTTPRequestHandler):
             "choices": [
                 {
                     "index": 0,
-                    "delta": {},  # Empty delta - full content is in message only
+                    "delta": {} if chunk_parts else {"content": full_content},
                     # Compatibility: some streaming clients inspect final message content only.
                     "message": {"role": "assistant", "content": full_content},
                     "finish_reason": "stop",

--- a/tests/test_openclaw_openai_server_streaming.py
+++ b/tests/test_openclaw_openai_server_streaming.py
@@ -84,7 +84,7 @@ def test_openclaw_openai_server_stream_includes_role_and_final_finish_reason() -
         assert choice["finish_reason"] is None
 
     last = chunks[-1]["choices"][0]
-    assert last["delta"].get("content") == "Hi!"
+    assert last["delta"] == {}
     assert last["finish_reason"] == "stop"
     assert last["message"]["role"] == "assistant"
     assert last["message"]["content"] == "Hi!"
@@ -166,7 +166,7 @@ def test_openclaw_openai_server_stream_uses_complete_content_when_no_chunks() ->
     )
     last = chunks[-1]["choices"][0]
     assert last["message"]["content"] == "from-complete"
-    assert last["delta"]["content"] == "from-complete"
+    assert last["delta"] == {"content": "from-complete"}
     usage = chunks[-1]["usage"]
     assert usage["total_tokens"] == 7
     assert usage["totalTokens"] == 7


### PR DESCRIPTION
## Summary
- handle both `chunk` and `text_chunk` events in the OpenClaw OpenAI-compatible stream adapter
- buffer draft chunks until cascade decision to prevent draft+verifier mixed SSE output
- drop buffered draft content on verifier switch and stream verifier output only
- fall back to `complete.result.content` when no chunk events are emitted
- add regression tests for text_chunk handling, draft->verifier switch behavior, and complete-only fallback

## Root cause
OpenClaw often calls CascadeFlow with tools enabled, which routes through `ToolStreamManager` and emits `text_chunk` events. The adapter previously consumed only `chunk`, so tool-path text could be lost. It also emitted draft chunks before quality decision, which could leak mixed output after a verifier switch.

## Validation
- `python3 -m pytest -q tests/test_openclaw_openai_server_streaming.py`
- `python3 -m pytest -q tests/test_openclaw_openai_server_auth.py`
