### PR TITLE
fix: streaming spec compliance for all cascadeflow users

### DIFF
--- a/cascadeflow/integrations/openclaw/openai_server.py
+++ b/cascadeflow/integrations/openclaw/openai_server.py
@@ -522,6 +522,12 @@ class OpenAIRequestHandler(BaseHTTPRequestHandler):
             completion_content = completion_result.get("content")
             if isinstance(completion_content, str):
                 full_content = completion_content
+        # If no content chunks were emitted (e.g. draft-accepted where buffering
+        # lost chunks), emit the content as a proper delta chunk now.  OpenAI SDKs
+        # only accumulate delta.content from chunks with finish_reason=null and
+        # ignore it on the stop chunk, so this must come before the final chunk.
+        if full_content and not chunk_parts:
+            _emit_chunk(full_content)
 
         prompt_tokens = int(completion_result.get("prompt_tokens") or 0)
         completion_tokens = int(completion_result.get("completion_tokens") or 0)

--- a/tests/test_openclaw_openai_server_streaming.py
+++ b/tests/test_openclaw_openai_server_streaming.py
@@ -169,9 +169,18 @@ def test_openclaw_openai_server_stream_uses_complete_content_when_no_chunks() ->
             )
         ]
     )
+    # Content must appear as a proper delta chunk (finish_reason=null) so that
+    # OpenAI SDKs accumulate it, not only in the stop chunk's delta.
+    content_deltas = [
+        c["choices"][0]["delta"].get("content", "")
+        for c in chunks
+        if c["choices"] and c["choices"][0].get("finish_reason") is None
+    ]
+    assert "from-complete" in content_deltas
+
     last = chunks[-1]["choices"][0]
     assert last["message"]["content"] == "from-complete"
-    assert last["delta"] == {"content": "from-complete"}
+    assert last["delta"] == {}
     usage = chunks[-1]["usage"]
     assert usage["total_tokens"] == 7
     assert usage["totalTokens"] == 7


### PR DESCRIPTION
## Summary
- **Proxy Gateway**: adds `protocol_version = "HTTP/1.1"`, `stream_options.include_usage` support (separate usage-only chunk with `choices: []`), `Connection: close` on all 4 streaming paths, and content fallback from `complete` event
- **OpenClaw Server**: emits fallback content as a proper `delta` chunk (`finish_reason: null`) before the stop chunk when no content chunks were captured — fixes **draft-accepted content loss** where OpenAI SDKs ignore `delta.content` on `finish_reason: "stop"` chunks
- Both servers now comply with the OpenAI streaming spec for SDK clients (Node SDK, Python SDK)

## Root cause (draft-accepted empty responses)
OpenAI SDKs only accumulate `delta.content` from chunks with `finish_reason: null`. When content appeared only in the stop chunk's `delta`, SDKs discarded it — producing empty final messages. This manifested as: draft accepted (~12k tokens) → empty, draft rejected + cascade (~25k tokens) → works.

## Test plan
- [x] All 6 OpenClaw streaming tests pass
- [x] All 20 proxy server/agent tests pass (26 total)
- [ ] Manual test with OpenClaw: verify draft-accepted responses return content