### PR TITLE
v0.7.1 patch release

### DIFF
--- a/cascadeflow/__init__.py
+++ b/cascadeflow/__init__.py
@@ -27,7 +27,7 @@ Example:
     >>> print(f"Used {result.model_used} - Cost: ${result.cost:.6f}")
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __author__ = "Sascha Buehrle"
 __license__ = "MIT"
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "cascadeflow TypeScript library - Smart AI model cascading for cost optimization",
   "author": {
     "name": "Lemony Inc.",

--- a/packages/integrations/n8n/package.json
+++ b/packages/integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/n8n-nodes-cascadeflow",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "n8n node for cascadeflow - Smart AI model cascading with 40-85% cost savings",
   "keywords": [
     "n8n-community-node-package",

--- a/packages/integrations/vercel-ai/package.json
+++ b/packages/integrations/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/vercel-ai",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "cascadeflow integration for the Vercel AI SDK (useChat handlers + provider ecosystem)",
   "author": {
     "name": "Lemony Inc.",

--- a/packages/langchain-cascadeflow/package.json
+++ b/packages/langchain-cascadeflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/langchain",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "LangChain integration for cascadeflow - Add intelligent cost optimization to your LangChain models",
   "author": {
     "name": "Lemony Inc.",

--- a/packages/ml/package.json
+++ b/packages/ml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/ml",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "ML semantic detection for cascadeflow TypeScript - Feature parity with Python",
   "author": {
     "name": "Lemony Inc.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cascadeflow"
-version = "0.7.0"
+version = "0.7.1"
 description = "Smart AI model cascading for cost optimization - Save 40-85% on LLM costs with 2-6x faster responses. Available for Python and TypeScript/JavaScript."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bump all 7 packages from 0.7.0 → 0.7.1
- Includes preset fixes already on main (Anthropic Opus 4.5 verifier)
- Re-publish `@cascadeflow/vercel-ai` (failed EOTP on first publish in v0.7.0)

## Packages
- `cascadeflow` (PyPI)
- `@cascadeflow/core`, `@cascadeflow/ml`, `@cascadeflow/langchain`, `@cascadeflow/n8n-nodes-cascadeflow`, `@cascadeflow/vercel-ai` (npm)

## Test plan
- [ ] CI green
- [ ] Manual first-time `npm publish` for `@cascadeflow/vercel-ai` with OTP