### PR TITLE
fix(n8n): eager model resolution for visual flow highlighting

### DIFF
--- a/packages/integrations/n8n/package.json
+++ b/packages/integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/n8n-nodes-cascadeflow",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "n8n node for cascadeflow - Smart AI model cascading with 40-85% cost savings",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Switch from lazy getters to eager `getInputConnectionData()` calls in `supplyData()` for both `LmChatCascadeFlow` and `CascadeFlowAgent` nodes
- n8n's execution engine now properly tracks and highlights connected model sub-nodes (Drafter, Verifier, domain models) during workflow runs
- Bump version to 0.7.3

## Test plan
- [x] Build clean (`pnpm build`)
- [x] All 7 tests pass (`pnpm test`)
- [x] Lint clean (`pnpm lint`)