### PR TITLE
fix(core): refresh Anthropic factory defaults to current model IDs

### DIFF
--- a/docs/guides/integrate_fast.md
+++ b/docs/guides/integrate_fast.md
@@ -61,7 +61,7 @@ import { CascadeAgent } from '@cascadeflow/core';
 const agent = new CascadeAgent({
   models: [
     { name: 'gpt-4o-mini', provider: 'openai', cost: 0.00015, apiKey: process.env.OPENAI_API_KEY },
-    { name: 'claude-3-5-sonnet-20241022', provider: 'anthropic', cost: 0.003, apiKey: process.env.ANTHROPIC_API_KEY },
+    { name: 'claude-sonnet-4-5-20250929', provider: 'anthropic', cost: 0.003, apiKey: process.env.ANTHROPIC_API_KEY },
   ],
 });
 

--- a/packages/core/src/__tests__/agent-factory.test.ts
+++ b/packages/core/src/__tests__/agent-factory.test.ts
@@ -98,8 +98,8 @@ describe('CascadeAgent Factory Methods', () => {
       const anthropicModels = agent['models'].filter(m => m.provider === 'anthropic');
 
       expect(anthropicModels.map(m => m.name)).toEqual([
-        'claude-3-5-haiku-20241022',
-        'claude-3-5-sonnet-20241022'
+        'claude-haiku-4-5-20251001',
+        'claude-sonnet-4-5-20250929'
       ]);
     });
 
@@ -159,16 +159,16 @@ describe('CascadeAgent Factory Methods', () => {
       process.env.ANTHROPIC_API_KEY = 'test-key';
 
       const profile = createUserProfile('PRO', 'user-789', {
-        preferredModels: ['gpt-4o', 'claude-3-5-sonnet-20241022']
+        preferredModels: ['gpt-4o', 'claude-sonnet-4-5-20250929']
       });
 
       const agent = CascadeAgent.fromProfile(profile);
       const modelNames = agent['models'].map(m => m.name);
 
       expect(modelNames).toContain('gpt-4o');
-      expect(modelNames).toContain('claude-3-5-sonnet-20241022');
+      expect(modelNames).toContain('claude-sonnet-4-5-20250929');
       expect(modelNames).not.toContain('gpt-4o-mini');
-      expect(modelNames).not.toContain('claude-3-5-haiku-20241022');
+      expect(modelNames).not.toContain('claude-haiku-4-5-20251001');
     });
 
     it('should include all available models when no preferred models specified', () => {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -357,8 +357,8 @@ export class CascadeAgent {
     // Add Anthropic models if available
     if (supportedAvailable.includes('anthropic')) {
       models.push(
-        { name: 'claude-3-5-haiku-20241022', provider: 'anthropic', cost: 0.0008 },
-        { name: 'claude-3-5-sonnet-20241022', provider: 'anthropic', cost: 0.003 }
+        { name: 'claude-haiku-4-5-20251001', provider: 'anthropic', cost: 0.001 },
+        { name: 'claude-sonnet-4-5-20250929', provider: 'anthropic', cost: 0.003 }
       );
     }
 
@@ -395,7 +395,7 @@ export class CascadeAgent {
    * import { createUserProfile, CascadeAgent } from '@cascadeflow/core';
    *
    * const profile = createUserProfile('PRO', 'user-123', {
-   *   preferredModels: ['gpt-4o', 'claude-3-5-sonnet-20241022']
+   *   preferredModels: ['gpt-4o', 'claude-sonnet-4-5-20250929']
    * });
    *
    * const agent = CascadeAgent.fromProfile(profile);
@@ -443,8 +443,8 @@ export class CascadeAgent {
     // Add Anthropic models if available
     if (supportedAvailable.includes('anthropic')) {
       const anthropicModels: ModelConfig[] = [
-        { name: 'claude-3-5-haiku-20241022', provider: 'anthropic', cost: 0.0008 },
-        { name: 'claude-3-5-sonnet-20241022', provider: 'anthropic', cost: 0.003 },
+        { name: 'claude-haiku-4-5-20251001', provider: 'anthropic', cost: 0.001 },
+        { name: 'claude-sonnet-4-5-20250929', provider: 'anthropic', cost: 0.003 },
       ];
 
       for (const model of anthropicModels) {


### PR DESCRIPTION
Summary\n- update CascadeAgent.fromEnv() Anthropic defaults to claude-haiku-4-5-20251001 and claude-sonnet-4-5-20250929\n- update CascadeAgent.fromProfile() Anthropic defaults to same IDs\n- update related factory tests and fast-integration doc snippet\n\nWhy\nCurrent defaults referenced older Anthropic IDs that can 404 for users, causing quickstart/factory setups to fail despite valid keys.\n\nValidation\n- pnpm --filter @cascadeflow/core test -- src/__tests__/agent-factory.test.ts\n- pnpm --filter @cascadeflow/core typecheck