### PR TITLE
fix(n8n): single getInputConnectionData call for correct model resolution

### DIFF
--- a/packages/integrations/n8n/nodes/CascadeFlowAgent/CascadeFlowAgent.node.ts
+++ b/packages/integrations/n8n/nodes/CascadeFlowAgent/CascadeFlowAgent.node.ts
@@ -768,20 +768,18 @@ export class CascadeFlowAgent implements INodeType {
       }
     }
 
-    // Eagerly resolve drafter model (index 1) — triggers n8n visual highlighting
-    const drafterData = await this.getInputConnectionData('ai_languageModel' as any, 1);
-    const resolvedDrafter = (Array.isArray(drafterData) ? drafterData[0] : drafterData) as BaseChatModel;
-    if (!resolvedDrafter) {
-      throw new NodeOperationError(
-        this.getNode(),
-        'Drafter model is required. Please connect your DRAFTER model to the Drafter port.'
-      );
-    }
-    const drafterModelGetter = async () => resolvedDrafter;
+    // Resolve ALL connected language models in a single getInputConnectionData call.
+    // n8n resolves ALL sub-nodes of the given connectionType (the 2nd param is a
+    // data-item index, NOT a port selector). The returned array is in reversed slot
+    // order due to internal unshift, so we reverse it back. This matches the
+    // built-in AI Agent node pattern (getChatModel in ToolsAgent/common.ts).
+    const allModelData = await this.getInputConnectionData('ai_languageModel' as any, 0);
+    const allModels = Array.isArray(allModelData)
+      ? ([...allModelData].reverse() as BaseChatModel[])
+      : [allModelData as BaseChatModel];
 
-    // Eagerly resolve verifier model (index 0) — triggers n8n visual highlighting
-    const verifierData = await this.getInputConnectionData('ai_languageModel' as any, 0);
-    const resolvedVerifier = (Array.isArray(verifierData) ? verifierData[0] : verifierData) as BaseChatModel;
+    // Port order after reverse: 0=Verifier, 1=Drafter, 2+=domain models/verifiers
+    const resolvedVerifier = allModels[0];
     if (!resolvedVerifier) {
       throw new NodeOperationError(
         this.getNode(),
@@ -790,39 +788,34 @@ export class CascadeFlowAgent implements INodeType {
     }
     const verifierModelGetter = async () => resolvedVerifier;
 
-    // Tools port is always at index 2 (after Verifier and Drafter)
-    const toolsData = await this.getInputConnectionData('ai_tool' as any, 2).catch(() => [] as any);
+    const resolvedDrafter = allModels[1];
+    if (!resolvedDrafter) {
+      throw new NodeOperationError(
+        this.getNode(),
+        'Drafter model is required. Please connect your DRAFTER model to the Drafter port.'
+      );
+    }
+    const drafterModelGetter = async () => resolvedDrafter;
+
+    // Tools use a separate connectionType so they have their own single call
+    const toolsData = await this.getInputConnectionData('ai_tool' as any, 0).catch(() => [] as any);
     const tools = (Array.isArray(toolsData) ? toolsData : toolsData ? [toolsData] : []) as ToolLike[];
 
-    // Eagerly resolve domain models — triggers n8n visual highlighting for each
+    // Domain models and domain verifiers occupy indices 2+ in slot definition order
     const domainModelGetters = new Map<DomainType, () => Promise<BaseChatModel | undefined>>();
     const domainVerifierGetters = new Map<DomainType, () => Promise<BaseChatModel | undefined>>();
 
-    let nextPortIndex = 3; // After Verifier (0), Drafter (1), Tools (2)
+    let nextModelIndex = 2; // After Verifier (0) and Drafter (1)
     for (const { domain, verifierToggleName } of DOMAIN_UI_CONFIGS) {
       if (!enabledDomains.includes(domain)) continue;
 
-      const drafterIndex = nextPortIndex++;
-      try {
-        const data = await this.getInputConnectionData('ai_languageModel' as any, drafterIndex);
-        const model = (Array.isArray(data) ? data[0] : data) as BaseChatModel;
-        const resolvedModel = model || undefined;
-        domainModelGetters.set(domain, async () => resolvedModel);
-      } catch {
-        domainModelGetters.set(domain, async () => undefined);
-      }
+      const model = allModels[nextModelIndex++] as BaseChatModel | undefined;
+      domainModelGetters.set(domain, async () => model || undefined);
 
       const useDomainVerifier = this.getNodeParameter(verifierToggleName, 0, false) as boolean;
       if (useDomainVerifier) {
-        const verifierIndex = nextPortIndex++;
-        try {
-          const data = await this.getInputConnectionData('ai_languageModel' as any, verifierIndex);
-          const model = (Array.isArray(data) ? data[0] : data) as BaseChatModel;
-          const resolvedModel = model || undefined;
-          domainVerifierGetters.set(domain, async () => resolvedModel);
-        } catch {
-          domainVerifierGetters.set(domain, async () => undefined);
-        }
+        const verifierModel = allModels[nextModelIndex++] as BaseChatModel | undefined;
+        domainVerifierGetters.set(domain, async () => verifierModel || undefined);
       }
     }
 

--- a/packages/integrations/n8n/package.json
+++ b/packages/integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/n8n-nodes-cascadeflow",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "n8n node for cascadeflow - Smart AI model cascading with 40-85% cost savings",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- **Critical fix**: n8n's `getInputConnectionData(type, N)` resolves ALL connected sub-nodes of that type — the 2nd param is `itemIndex`, not a port selector. Previous code called it per-port, causing both drafter and verifier to resolve to the same model.
- Now uses n8n's built-in AI Agent pattern: single call, reverse the array, index by slot position
- Fixes visual flow highlighting — all connected models highlight correctly during execution
- Bump version to 0.7.4

## What was broken
Each `getInputConnectionData('ai_languageModel', N)` call returned the full array of ALL connected models. Taking `[0]` from each call meant both verifier and drafter pointed to the same model (first in the unreversed array = last slot's model).

## Test plan
- [x] Build clean
- [x] All 7 tests pass
- [x] Lint clean