### PR TITLE
fix(n8n): move domain verifiers toggle to visible position

### DIFF
--- a/packages/integrations/n8n/nodes/CascadeFlowAgent/CascadeFlowAgent.node.ts
+++ b/packages/integrations/n8n/nodes/CascadeFlowAgent/CascadeFlowAgent.node.ts
@@ -419,7 +419,6 @@ function generateDomainProperties(): any[] {
       default: false,
       description: 'Whether to enable intelligent routing based on detected query domain (math, code, legal, etc.)',
     },
-    ...domainToggleProperties,
     {
       displayName: 'Enable Domain Verifiers',
       name: 'enableDomainVerifiers',
@@ -428,6 +427,7 @@ function generateDomainProperties(): any[] {
       displayOptions: { show: { enableDomainRouting: [true] } },
       description: 'Whether to add a domain-specific verifier port for each enabled domain. Connect a model to override the global verifier for that domain.',
     },
+    ...domainToggleProperties,
     {
       displayName: 'Domain-Specific Settings',
       name: 'domainSettings',

--- a/packages/integrations/n8n/nodes/LmChatCascadeFlow/LmChatCascadeFlow.node.ts
+++ b/packages/integrations/n8n/nodes/LmChatCascadeFlow/LmChatCascadeFlow.node.ts
@@ -1393,8 +1393,6 @@ function generateDomainProperties(): any[] {
       default: false,
       description: 'Whether to enable intelligent routing based on detected query domain (math, code, legal, etc.)',
     },
-    // Individual domain toggles - each one adds its own model input port
-    ...domainToggleProperties,
     {
       displayName: 'Enable Domain Verifiers',
       name: 'enableDomainVerifiers',
@@ -1403,6 +1401,8 @@ function generateDomainProperties(): any[] {
       displayOptions: { show: { enableDomainRouting: [true] } },
       description: 'Whether to add a domain-specific verifier port for each enabled domain. Connect a model to override the global verifier for that domain.',
     },
+    // Individual domain toggles - each one adds its own model input port
+    ...domainToggleProperties,
     {
       displayName: 'Domain-Specific Settings',
       name: 'domainSettings',

--- a/packages/integrations/n8n/package.json
+++ b/packages/integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/n8n-nodes-cascadeflow",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "n8n node for cascadeflow - Smart AI model cascading with 40-85% cost savings",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Move `enableDomainVerifiers` toggle directly below `enableDomainRouting` so it's immediately visible when domain routing is enabled (was buried after 16 domain toggles)
- Bump to v0.7.6

## Test plan
- [x] Build, tests (7/7), lint all pass
- [ ] Enable domain routing → "Enable Domain Verifiers" toggle visible right below