### PR TITLE
fix(n8n): rename to Domain Cascading, clarify verifier fallback

### DIFF
--- a/packages/integrations/n8n/nodes/CascadeFlowAgent/CascadeFlowAgent.node.ts
+++ b/packages/integrations/n8n/nodes/CascadeFlowAgent/CascadeFlowAgent.node.ts
@@ -413,14 +413,14 @@ function generateDomainProperties(): any[] {
 
   return [
     {
-      displayName: 'Enable Domain Routing',
+      displayName: 'Enable Domain Cascading',
       name: 'enableDomainRouting',
       type: 'boolean',
       default: false,
-      description: 'Whether to enable intelligent routing based on detected query domain (math, code, legal, etc.)',
+      description: 'Whether to enable domain-specific cascading based on detected query domain (math, code, legal, etc.)',
     },
     {
-      displayName: 'Enable Domain Verifiers',
+      displayName: 'Enable Domain Verifiers (Default: Main Verifier)',
       name: 'enableDomainVerifiers',
       type: 'boolean',
       default: false,
@@ -720,7 +720,7 @@ export class CascadeFlowAgent implements INodeType {
         description: 'Override routing for specific tools (e.g., force verifier after tool call)',
       },
       {
-        displayName: 'Domain Routing',
+        displayName: 'Domain Cascading',
         name: 'domainRoutingHeading',
         type: 'notice',
         default: '',

--- a/packages/integrations/n8n/nodes/LmChatCascadeFlow/LmChatCascadeFlow.node.ts
+++ b/packages/integrations/n8n/nodes/LmChatCascadeFlow/LmChatCascadeFlow.node.ts
@@ -1387,14 +1387,14 @@ function generateDomainProperties(): any[] {
 
   return [
     {
-      displayName: 'Enable Domain Routing',
+      displayName: 'Enable Domain Cascading',
       name: 'enableDomainRouting',
       type: 'boolean',
       default: false,
-      description: 'Whether to enable intelligent routing based on detected query domain (math, code, legal, etc.)',
+      description: 'Whether to enable domain-specific cascading based on detected query domain (math, code, legal, etc.)',
     },
     {
-      displayName: 'Enable Domain Verifiers',
+      displayName: 'Enable Domain Verifiers (Default: Main Verifier)',
       name: 'enableDomainVerifiers',
       type: 'boolean',
       default: false,
@@ -1641,7 +1641,7 @@ export class LmChatCascadeFlow implements INodeType {
         description: 'Whether to validate drafter tool calls (JSON syntax, schema, safety) before accepting them. When validation fails, tool calls are escalated to the verifier.',
       },
       {
-        displayName: 'Domain Routing',
+        displayName: 'Domain Cascading',
         name: 'domainRoutingHeading',
         type: 'notice',
         default: '',

--- a/packages/integrations/n8n/package.json
+++ b/packages/integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/n8n-nodes-cascadeflow",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "n8n node for cascadeflow - Smart AI model cascading with 40-85% cost savings",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Rename "Enable Domain Routing" → "Enable Domain Cascading" in both nodes
- Update "Enable Domain Verifiers" label to "Enable Domain Verifiers (Default: Main Verifier)" so users know the fallback
- Bump to v0.7.8

## Test plan
- [x] Build, tests (7/7), lint all pass