### PR TITLE
docs(langchain): refresh Anthropic model IDs in examples and guides

### DIFF
--- a/docs/guides/langchain_integration.md
+++ b/docs/guides/langchain_integration.md
@@ -205,7 +205,7 @@ const verifier = new ChatOpenAI({ model: 'gpt-4o' });
 import { ChatAnthropic } from '@langchain/anthropic';
 
 const drafter = new ChatAnthropic({ modelName: 'claude-3-haiku-20240307' });
-const verifier = new ChatAnthropic({ modelName: 'claude-3-5-sonnet-20241022' });
+const verifier = new ChatAnthropic({ modelName: 'claude-sonnet-4-6' });
 ```
 
 **Mix and Match:**

--- a/packages/langchain-cascadeflow/README.md
+++ b/packages/langchain-cascadeflow/README.md
@@ -351,15 +351,15 @@ const verifier = new ChatOpenAI({ model: 'gpt-5' });
 ```typescript
 import { ChatAnthropic } from '@langchain/anthropic';
 
-const drafter = new ChatAnthropic({ model: 'claude-3-5-haiku-20241022' });
-const verifier = new ChatAnthropic({ model: 'claude-sonnet-4-5' });
+const drafter = new ChatAnthropic({ model: 'claude-3-haiku-20240307' });
+const verifier = new ChatAnthropic({ model: 'claude-sonnet-4-6' });
 ```
 
 ### Mix and Match (Recommended)
 ```typescript
 // Use different providers for optimal cost/quality balance!
 const drafter = new ChatOpenAI({ model: 'gpt-5-mini' });
-const verifier = new ChatAnthropic({ model: 'claude-sonnet-4-5' });
+const verifier = new ChatAnthropic({ model: 'claude-sonnet-4-6' });
 ```
 
 ## Cost Optimization Tips
@@ -367,7 +367,7 @@ const verifier = new ChatAnthropic({ model: 'claude-sonnet-4-5' });
 1. **Choose Your Drafter Wisely** - Use the cheapest model that can handle most queries
    - GPT-5-mini: $0.25/$2.00 per 1M tokens (input/output)
    - GPT-4o-mini: $0.15/$0.60 per 1M tokens (input/output)
-   - Claude 3.5 Haiku: $0.80/$4.00 per 1M tokens
+   - Claude 3 Haiku: $0.25/$1.25 per 1M tokens
 
 2. **Tune Quality Threshold** - Higher threshold = more cascades = higher cost but better quality
    - `0.6` - Aggressive cost savings, may sacrifice some quality

--- a/packages/langchain-cascadeflow/examples/cross-provider-escalation.ts
+++ b/packages/langchain-cascadeflow/examples/cross-provider-escalation.ts
@@ -94,9 +94,9 @@ async function main() {
 
   console.log(`${COLORS.bold}🤖 Creating Cross-Provider Cascade${COLORS.reset}\n`);
 
-  // Drafter: Claude 3.5 Haiku (Anthropic) - Fast, cheap
+  // Drafter: Claude 3 Haiku (Anthropic) - Fast, cheap
   const haiku = new ChatAnthropic({
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-3-haiku-20240307',
     temperature: 1.0,
   });
 
@@ -116,7 +116,7 @@ async function main() {
   });
 
   console.log(`${COLORS.green}✓ Cascade configured${COLORS.reset}`);
-  console.log(`  Drafter: ${COLORS.cyan}Claude 3.5 Haiku${COLORS.reset} (Anthropic)`);
+  console.log(`  Drafter: ${COLORS.cyan}Claude 3 Haiku${COLORS.reset} (Anthropic)`);
   console.log(`  Verifier: ${COLORS.cyan}GPT-5${COLORS.reset} (OpenAI)`);
   console.log(`  Quality Threshold: 0.7`);
   console.log(`  PreRouter: ${COLORS.green}Enabled${COLORS.reset} (hard/expert queries → direct to GPT-5)\n`);
@@ -191,11 +191,11 @@ async function main() {
   console.log(`${COLORS.bold}What You'll See:${COLORS.reset}\n`);
 
   console.log(`${COLORS.green}1. For Cascaded Queries (Haiku only):${COLORS.reset}`);
-  console.log(`   • Single trace: ${COLORS.cyan}ChatAnthropic${COLORS.reset} (claude-3-5-haiku)`);
+  console.log(`   • Single trace: ${COLORS.cyan}ChatAnthropic${COLORS.reset} (claude-3-haiku-20240307)`);
   console.log(`   • Cascade metadata shows: ${COLORS.green}model_used: "drafter"${COLORS.reset}\n`);
 
   console.log(`${COLORS.yellow}2. For Escalated Queries (Haiku → GPT-5):${COLORS.reset}`);
-  console.log(`   • First trace: ${COLORS.cyan}ChatAnthropic${COLORS.reset} (claude-3-5-haiku) - tried first`);
+  console.log(`   • First trace: ${COLORS.cyan}ChatAnthropic${COLORS.reset} (claude-3-haiku-20240307) - tried first`);
   console.log(`   • Second trace: ${COLORS.cyan}ChatOpenAI${COLORS.reset} (gpt-5) - used for response`);
   console.log(`   • Cascade metadata shows: ${COLORS.yellow}model_used: "verifier"${COLORS.reset}\n`);
 

--- a/packages/langchain-cascadeflow/examples/full-benchmark-semantic.ts
+++ b/packages/langchain-cascadeflow/examples/full-benchmark-semantic.ts
@@ -293,16 +293,16 @@ async function main() {
   // Cross-Provider (Anthropic → OpenAI)
   if (process.env.ANTHROPIC_API_KEY) {
     modelPairs.push({
-      name: 'Claude 3.5 Haiku → GPT-5',
-      drafter: new ChatAnthropic({ model: 'claude-3-5-haiku-20241022' }),
+      name: 'Claude 3 Haiku → GPT-5',
+      drafter: new ChatAnthropic({ model: 'claude-3-haiku-20240307' }),
       verifier: new ChatOpenAI({ model: 'gpt-5', temperature: 1.0 }),
       provider: 'Cross-Provider (Anthropic→OpenAI)',
       expectedSavings: '80%',
     });
 
     modelPairs.push({
-      name: 'Claude 3.5 Haiku → GPT-5 Mini',
-      drafter: new ChatAnthropic({ model: 'claude-3-5-haiku-20241022' }),
+      name: 'Claude 3 Haiku → GPT-5 Mini',
+      drafter: new ChatAnthropic({ model: 'claude-3-haiku-20240307' }),
       verifier: new ChatOpenAI({ model: 'gpt-5-mini', temperature: 1.0 }),
       provider: 'Cross-Provider (Anthropic→OpenAI)',
       expectedSavings: '60%',

--- a/packages/langchain-cascadeflow/examples/langsmith-all-models.ts
+++ b/packages/langchain-cascadeflow/examples/langsmith-all-models.ts
@@ -135,16 +135,16 @@ async function main() {
   } else {
     // Test 4: Claude Haiku → GPT-5
     await testModelPair(
-      'Claude 3.5 Haiku → GPT-5 (80% savings)',
-      new ChatAnthropic({ model: 'claude-3-5-haiku-20241022' }),
+      'Claude 3 Haiku → GPT-5 (80% savings)',
+      new ChatAnthropic({ model: 'claude-3-haiku-20240307' }),
       new ChatOpenAI({ modelName: 'gpt-5', temperature: 1.0 }),
       'Cross-Provider'
     );
 
     // Test 5: Claude Haiku → GPT-5 Mini
     await testModelPair(
-      'Claude 3.5 Haiku → GPT-5 Mini (60% savings)',
-      new ChatAnthropic({ model: 'claude-3-5-haiku-20241022' }),
+      'Claude 3 Haiku → GPT-5 Mini (60% savings)',
+      new ChatAnthropic({ model: 'claude-3-haiku-20240307' }),
       new ChatOpenAI({ modelName: 'gpt-5-mini', temperature: 1.0 }),
       'Cross-Provider'
     );

--- a/packages/langchain-cascadeflow/examples/realistic-usage-langsmith.ts
+++ b/packages/langchain-cascadeflow/examples/realistic-usage-langsmith.ts
@@ -146,7 +146,7 @@ async function main() {
     console.log(`${COLORS.bold}🔀 Bonus: Cross-Provider Cascade (Anthropic → OpenAI)${COLORS.reset}\n`);
 
     const claudeDrafter = new ChatAnthropic({
-      model: 'claude-3-5-haiku-20241022',
+      model: 'claude-3-haiku-20240307',
     });
 
     const crossProviderCascade = new CascadeFlow({
@@ -158,7 +158,7 @@ async function main() {
     });
 
     console.log(`${COLORS.green}✓ Created cross-provider cascade${COLORS.reset}`);
-    console.log(`  Drafter: Claude 3.5 Haiku (Anthropic)`);
+    console.log(`  Drafter: Claude 3 Haiku (Anthropic)`);
     console.log(`  Verifier: GPT-5 (OpenAI)\n`);
 
     const crossQuery = 'Explain the benefits of TypeScript';
@@ -172,7 +172,7 @@ async function main() {
 
     if (stats) {
       const decision = stats.modelUsed === 'drafter' ? 'CASCADED' : 'ESCALATED';
-      const model = stats.modelUsed === 'drafter' ? 'Claude 3.5 Haiku' : 'GPT-5';
+      const model = stats.modelUsed === 'drafter' ? 'Claude 3 Haiku' : 'GPT-5';
 
       console.log(`  ${decision} (quality: ${stats.drafterQuality?.toFixed(2)})`);
       console.log(`  Model: ${model}\n`);


### PR DESCRIPTION
## Summary\n- replace stale Anthropic model IDs in LangChain public examples/docs\n- align README and guide snippets with currently valid Anthropic IDs\n- keep scope limited to LangChain integration documentation/examples\n\n## Validation\n- pnpm -C packages/langchain-cascadeflow test\n- pnpm -C packages/langchain-cascadeflow typecheck