### PR TITLE
chore(vercel-ai): bump package version to 0.7.3

### DIFF
--- a/packages/integrations/vercel-ai/package.json
+++ b/packages/integrations/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascadeflow/vercel-ai",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "cascadeflow integration for the Vercel AI SDK (useChat handlers + provider ecosystem)",
   "author": {
     "name": "Lemony Inc.",


### PR DESCRIPTION
## Summary
- bump `@cascadeflow/vercel-ai` from `0.7.2` to `0.7.3`
- no code-path changes, release-only version bump

## Validation
- `pnpm -C packages/integrations/vercel-ai test`
- `pnpm -C packages/integrations/vercel-ai typecheck`
- `pnpm -C packages/integrations/vercel-ai build`
