### PR TITLE
Harden v1 security posture and safe example tooling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,8 +243,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install pip-audit bandit
 
-      - name: Run pip-audit
-        run: pip-audit --requirement requirements.txt --requirement requirements-dev.txt || true
+      - name: Run pip-audit (core runtime dependencies)
+        run: pip-audit --requirement requirements.txt
 
       - name: Run Bandit security scan
-        run: bandit -r cascadeflow/ -ll || true
+        run: bandit -r cascadeflow/ -ll

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We release security updates for the following versions of cascadeflow:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
-| < 0.1   | :x:                |
+| 0.7.x   | :white_check_mark: |
+| < 0.7   | :x:                |
 
 We recommend always using the latest version for the best security and features.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -79,6 +79,7 @@ pip install cascadeflow  # Core only, no extras needed!
 # Run vLLM server, connect via HTTP
 
 # Option 2: Python package
+# Requires Python 3.10+
 pip install cascadeflow[vllm]
 ```
 

--- a/docs/guides/langchain_integration.md
+++ b/docs/guides/langchain_integration.md
@@ -331,7 +331,8 @@ const agent = new CascadeAgent({
   model: cascade,
   maxSteps: 6,
   toolHandlers: {
-    calculator: async ({ expression }) => eval(expression).toString(),
+    // Use a strict parser helper (see examples/nodejs/safe-math.ts).
+    calculator: async ({ expression }) => safeCalculateExpression(expression).toString(),
   },
 });
 
@@ -350,7 +351,8 @@ cascade = CascadeFlow(drafter=drafter, verifier=verifier)
 agent = CascadeAgent(
     model=cascade.bind_tools(tools),
     max_steps=6,
-    tool_handlers={"calculator": lambda args: str(eval(args["expression"]))},
+    # Use a strict parser helper (see examples/agentic_multi_agent.py).
+    tool_handlers={"calculator": lambda args: str(safe_calculate(args["expression"]))},
 )
 
 result = await agent.arun(

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -45,8 +45,8 @@ cascadeflow provides **real-time streaming** for both text responses and tool ca
 # Basic streaming (text only)
 pip install cascadeflow
 
-# Tool streaming (includes JSON parser)
-pip install cascadeflow[tools]
+# Tool streaming (includes JSON parser in the core package)
+pip install cascadeflow
 
 # All features
 pip install cascadeflow[all]

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -306,10 +306,11 @@ const complexResult = await agent.run(
 // → Routes directly to best model (complex query)
 
 // ToolRouter: Filters to tool-capable models
+// Use a strict parser helper (see examples/nodejs/safe-math.ts).
 const calculatorTool = createTool({
   name: 'calculator',
   description: 'Perform calculations',
-  function: async ({ expression }) => eval(expression),
+  function: async ({ expression }) => safeCalculateExpression(expression),
 });
 
 const toolResult = await agent.run('Calculate 125 * 47', {

--- a/packages/core/examples/nodejs/agentic-multi-agent.ts
+++ b/packages/core/examples/nodejs/agentic-multi-agent.ts
@@ -19,21 +19,11 @@ import {
   type Message,
   type Tool,
 } from '@cascadeflow/core';
+import { safeCalculateExpression } from './safe-math';
 
 function safeCalculate(expression: string): { expression: string; result?: number; error?: string } {
   try {
-    const expr = expression
-      .replace(/sqrt\(([^)]+)\)/g, 'Math.sqrt($1)')
-      .replace(/pow\(([^,]+),([^)]+)\)/g, 'Math.pow($1,$2)')
-      .replace(/abs\(([^)]+)\)/g, 'Math.abs($1)');
-
-    // Minimal validation to avoid code injection in an example.
-    if (!/^[\d\s+\-*/().,Math]+$/.test(expr)) {
-      return { expression, error: 'Invalid expression' };
-    }
-
-    // eslint-disable-next-line no-eval
-    const result = eval(expr);
+    const result = safeCalculateExpression(expression);
     return { expression, result };
   } catch (e) {
     return { expression, error: e instanceof Error ? e.message : String(e) };
@@ -208,4 +198,3 @@ main().catch((e) => {
   console.error(e);
   process.exit(1);
 });
-

--- a/packages/core/examples/nodejs/router-integration.ts
+++ b/packages/core/examples/nodejs/router-integration.ts
@@ -10,6 +10,7 @@
  */
 
 import { CascadeAgent, createTool } from '@cascadeflow/core';
+import { safeCalculateExpression } from './safe-math';
 
 async function main() {
   console.log('🔀 Router Integration Example\n');
@@ -76,7 +77,7 @@ async function main() {
     },
     function: async ({ expression }: { expression: string }) => {
       try {
-        const result = eval(expression);
+        const result = safeCalculateExpression(expression);
         return `Result: ${result}`;
       } catch (error) {
         return `Error: ${error instanceof Error ? error.message : 'Calculation failed'}`;

--- a/packages/core/examples/nodejs/safe-math.ts
+++ b/packages/core/examples/nodejs/safe-math.ts
@@ -1,0 +1,181 @@
+/**
+ * Safe arithmetic evaluator for examples.
+ *
+ * Supported:
+ * - Binary operators: +, -, *, /
+ * - Parentheses
+ * - Unary + and -
+ * - Functions: sqrt(x), abs(x), pow(x, y)
+ */
+
+type MathFn = (args: number[]) => number;
+
+const FUNCTIONS: Record<string, MathFn> = {
+  sqrt: (args) => {
+    if (args.length !== 1) {
+      throw new Error('sqrt() expects exactly 1 argument');
+    }
+    return Math.sqrt(args[0]);
+  },
+  abs: (args) => {
+    if (args.length !== 1) {
+      throw new Error('abs() expects exactly 1 argument');
+    }
+    return Math.abs(args[0]);
+  },
+  pow: (args) => {
+    if (args.length !== 2) {
+      throw new Error('pow() expects exactly 2 arguments');
+    }
+    return Math.pow(args[0], args[1]);
+  },
+};
+
+function tokenize(expression: string): string[] {
+  const tokens: string[] = [];
+  const pattern = /\s*([A-Za-z_][A-Za-z0-9_]*|\d+(?:\.\d+)?|\.\d+|[()+\-*/,])\s*/gy;
+  let cursor = 0;
+
+  while (cursor < expression.length) {
+    pattern.lastIndex = cursor;
+    const match = pattern.exec(expression);
+    if (!match) {
+      throw new Error(`Invalid token near "${expression.slice(cursor, cursor + 12)}"`);
+    }
+    tokens.push(match[1]);
+    cursor = pattern.lastIndex;
+  }
+
+  return tokens;
+}
+
+class MathParser {
+  private readonly tokens: string[];
+  private index = 0;
+
+  constructor(expression: string) {
+    this.tokens = tokenize(expression);
+  }
+
+  parse(): number {
+    const value = this.parseExpression();
+    if (!this.isAtEnd()) {
+      throw new Error(`Unexpected token "${this.peek()}"`);
+    }
+    return value;
+  }
+
+  private parseExpression(): number {
+    let value = this.parseTerm();
+    while (this.peek() === '+' || this.peek() === '-') {
+      const operator = this.consume();
+      const right = this.parseTerm();
+      value = operator === '+' ? value + right : value - right;
+    }
+    return value;
+  }
+
+  private parseTerm(): number {
+    let value = this.parseFactor();
+    while (this.peek() === '*' || this.peek() === '/') {
+      const operator = this.consume();
+      const right = this.parseFactor();
+      if (operator === '/') {
+        if (right === 0) {
+          throw new Error('Division by zero');
+        }
+        value /= right;
+      } else {
+        value *= right;
+      }
+    }
+    return value;
+  }
+
+  private parseFactor(): number {
+    const token = this.peek();
+    if (!token) {
+      throw new Error('Unexpected end of expression');
+    }
+
+    if (token === '+' || token === '-') {
+      const operator = this.consume();
+      const value = this.parseFactor();
+      return operator === '-' ? -value : value;
+    }
+
+    if (token === '(') {
+      this.consume(); // (
+      const value = this.parseExpression();
+      this.expect(')');
+      return value;
+    }
+
+    if (/^\d+(?:\.\d+)?$/.test(token) || /^\.\d+$/.test(token)) {
+      const numberToken = this.consume();
+      const value = Number(numberToken);
+      if (!Number.isFinite(value)) {
+        throw new Error('Invalid numeric value');
+      }
+      return value;
+    }
+
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(token)) {
+      const name = this.consume();
+      const fn = FUNCTIONS[name];
+      if (!fn) {
+        throw new Error(`Unsupported function "${name}"`);
+      }
+      this.expect('(');
+      const args: number[] = [];
+      if (this.peek() !== ')') {
+        args.push(this.parseExpression());
+        while (this.peek() === ',') {
+          this.consume();
+          args.push(this.parseExpression());
+        }
+      }
+      this.expect(')');
+      const value = fn(args);
+      if (!Number.isFinite(value)) {
+        throw new Error(`Function "${name}" returned a non-finite value`);
+      }
+      return value;
+    }
+
+    throw new Error(`Unexpected token "${token}"`);
+  }
+
+  private peek(): string | undefined {
+    return this.tokens[this.index];
+  }
+
+  private consume(): string {
+    const token = this.tokens[this.index];
+    this.index += 1;
+    return token;
+  }
+
+  private expect(expected: string): void {
+    const actual = this.consume();
+    if (actual !== expected) {
+      throw new Error(`Expected "${expected}" but received "${actual ?? 'end of input'}"`);
+    }
+  }
+
+  private isAtEnd(): boolean {
+    return this.index >= this.tokens.length;
+  }
+}
+
+export function safeCalculateExpression(expression: string): number {
+  const trimmed = expression.trim();
+  if (!trimmed) {
+    throw new Error('Expression is required');
+  }
+  if (trimmed.length > 200) {
+    throw new Error('Expression is too long');
+  }
+  return new MathParser(trimmed).parse();
+}
+

--- a/packages/core/examples/nodejs/streaming-tools.ts
+++ b/packages/core/examples/nodejs/streaming-tools.ts
@@ -11,6 +11,7 @@
  */
 
 import { CascadeAgent, StreamEventType } from '@cascadeflow/core';
+import { safeCalculateExpression } from './safe-math';
 
 // ============================================================================
 // Tool Definitions
@@ -149,15 +150,7 @@ function executeSearchTool(args: { query: string; num_results?: number }): any {
 
 function executeCalculatorTool(args: { expression: string }): any {
   try {
-    const expr = args.expression
-      .replace(/sqrt\(([^)]+)\)/g, 'Math.sqrt($1)')
-      .replace(/pow\(([^,]+),([^)]+)\)/g, 'Math.pow($1,$2)');
-
-    if (!/^[\d\s+\-*/().Math]+$/.test(expr)) {
-      return { error: 'Invalid expression', expression: args.expression };
-    }
-
-    const result = eval(expr);
+    const result = safeCalculateExpression(args.expression);
     return {
       expression: args.expression,
       result,

--- a/packages/core/examples/nodejs/tool-execution.ts
+++ b/packages/core/examples/nodejs/tool-execution.ts
@@ -12,6 +12,7 @@
  */
 
 import { CascadeAgent } from '@cascadeflow/core';
+import { safeCalculateExpression } from './safe-math';
 
 // ============================================================================
 // Tool Definitions
@@ -153,18 +154,7 @@ function executeWeatherTool(args: { location: string; units?: string }): string 
  */
 function executeCalculatorTool(args: { expression: string }): string {
   try {
-    // Safe evaluation for basic math
-    const expr = args.expression
-      .replace(/sqrt\(([^)]+)\)/g, 'Math.sqrt($1)')
-      .replace(/pow\(([^,]+),([^)]+)\)/g, 'Math.pow($1,$2)')
-      .replace(/abs\(([^)]+)\)/g, 'Math.abs($1)');
-
-    // Simple validation to prevent code injection
-    if (!/^[\d\s+\-*/().Math]+$/.test(expr)) {
-      throw new Error('Invalid expression');
-    }
-
-    const result = eval(expr);
+    const result = safeCalculateExpression(args.expression);
     return JSON.stringify({
       expression: args.expression,
       result,

--- a/packages/integrations/n8n/package.json
+++ b/packages/integrations/n8n/package.json
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@langchain/core": "^0.3.0",
+    "@langchain/core": "^1.1.0",
     "@cascadeflow/core": "^0.6.0"
   }
 }

--- a/packages/integrations/vercel-ai/package.json
+++ b/packages/integrations/vercel-ai/package.json
@@ -56,7 +56,6 @@
     "@ai-sdk/deepseek": "^2.0.0",
     "@ai-sdk/fireworks": "^2.0.0",
     "@ai-sdk/google": "^1.0.0 || ^2.0.0 || ^3.0.0",
-    "@ai-sdk/google-vertex": "^4.0.0",
     "@ai-sdk/groq": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "@ai-sdk/mistral": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "@ai-sdk/openai": "^1.0.0 || ^2.0.0 || ^3.0.0",
@@ -94,9 +93,6 @@
       "optional": true
     },
     "@ai-sdk/google": {
-      "optional": true
-    },
-    "@ai-sdk/google-vertex": {
       "optional": true
     },
     "@ai-sdk/groq": {

--- a/packages/langchain-cascadeflow/README.md
+++ b/packages/langchain-cascadeflow/README.md
@@ -195,7 +195,8 @@ const tools = [
     name: 'calculator',
     description: 'Useful for math calculations',
     func: async (input: string) => {
-      return eval(input).toString();
+      // Use a strict parser helper (see examples/nodejs/safe-math.ts).
+      return safeCalculateExpression(input).toString();
     },
   },
 ];
@@ -243,7 +244,8 @@ const agent = new CascadeAgent({
   model: cascadeModel.bindTools(tools),
   maxSteps: 6,
   toolHandlers: {
-    calculator: async ({ expression }) => eval(expression).toString(),
+    // Use the same strict parser helper (see examples/nodejs/safe-math.ts).
+    calculator: async ({ expression }) => safeCalculateExpression(expression).toString(),
   },
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^0.6.0
         version: 0.6.5
       '@langchain/core':
-        specifier: ^0.3.0
-        version: 0.3.80
+        specifier: ^1.1.0
+        version: 1.1.26(openai@4.104.0)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -209,9 +209,6 @@ importers:
       '@ai-sdk/google':
         specifier: ^1.0.0 || ^2.0.0 || ^3.0.0
         version: 1.2.22(zod@3.25.76)
-      '@ai-sdk/google-vertex':
-        specifier: ^4.0.0
-        version: 4.0.48(zod@3.25.76)
       '@ai-sdk/groq':
         specifier: ^1.0.0 || ^2.0.0 || ^3.0.0
         version: 1.2.9(zod@3.25.76)
@@ -457,22 +454,6 @@ packages:
       zod: 4.3.6
     dev: false
 
-  /@ai-sdk/google-vertex@4.0.48(zod@3.25.76):
-    resolution: {integrity: sha512-rYeYF/f/cwMZqdpzmbT1O1UMUJ8A/QVKoEA2AIs12E1qTGrcVVSnviF59hzeEgyzn15cAZYObXBsqqkzBGLwLA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-    dependencies:
-      '@ai-sdk/anthropic': 3.0.39(zod@3.25.76)
-      '@ai-sdk/google': 3.0.23(zod@3.25.76)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@3.25.76)
-      google-auth-library: 10.5.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@ai-sdk/google@1.2.22(zod@3.25.76):
     resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
     engines: {node: '>=18'}
@@ -481,17 +462,6 @@ packages:
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      zod: 3.25.76
-    dev: false
-
-  /@ai-sdk/google@3.0.23(zod@3.25.76):
-    resolution: {integrity: sha512-/fV5KKw73+Vqcw/SwlNsdzJytTY3mlPrrba69gIbU4GmY4KtFkNZ0EGxNCMb3uFkq9Ba2GQ5vYHnUkhCftY8Eg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@3.25.76)
       zod: 3.25.76
     dev: false
 
@@ -1589,18 +1559,6 @@ packages:
     dev: false
     optional: true
 
-  /@isaacs/cliui@8.0.2:
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: /string-width@4.2.3
-      strip-ansi: 7.1.2
-      strip-ansi-cjs: /strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: false
-
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1640,29 +1598,6 @@ packages:
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.6)
       '@langchain/core': 1.1.26(openai@4.104.0)
       zod: 4.3.6
-    dev: false
-
-  /@langchain/core@0.3.80:
-    resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.21
-      langsmith: 0.3.87
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
     dev: false
 
   /@langchain/core@1.1.26(openai@4.104.0):
@@ -1886,13 +1821,6 @@ packages:
   /@opentelemetry/api@1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-
-  /@pkgjs/parseargs@0.11.0:
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@protobufjs/aspromise@1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2336,10 +2264,6 @@ packages:
       csstype: 3.2.3
     dev: true
 
-  /@types/retry@0.12.0:
-    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
-    dev: false
-
   /@types/semver@7.7.1:
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
     dev: true
@@ -2673,11 +2597,6 @@ packages:
     hasBin: true
     dev: true
 
-  /agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
-    dev: false
-
   /agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -2781,11 +2700,7 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-
-  /ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-    dev: false
+    dev: true
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -2796,6 +2711,7 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+    dev: true
 
   /ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -3007,6 +2923,7 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
 
   /bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
@@ -3103,10 +3020,6 @@ packages:
     hasBin: true
     dev: false
 
-  /bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-    dev: false
-
   /binary-extensions@1.13.1:
     resolution: {integrity: sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==}
     engines: {node: '>=0.10.0'}
@@ -3156,6 +3069,7 @@ packages:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
     dependencies:
       balanced-match: 1.0.2
+    dev: true
 
   /braces@2.3.2:
     resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
@@ -3181,10 +3095,6 @@ packages:
     dependencies:
       fill-range: 7.1.1
     dev: true
-
-  /buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-    dev: false
 
   /buffer-equal@1.0.1:
     resolution: {integrity: sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==}
@@ -3547,6 +3457,7 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
 
   /crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
@@ -3563,11 +3474,6 @@ packages:
       es5-ext: 0.10.64
       type: 2.7.3
     dev: true
-
-  /data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3590,6 +3496,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+    dev: true
 
   /decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
@@ -3745,26 +3652,13 @@ packages:
       object.defaults: 1.1.0
     dev: true
 
-  /eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: false
-
-  /ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: true
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  /emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: false
+    dev: true
 
   /encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -4209,6 +4103,7 @@ packages:
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: true
 
   /extglob@2.0.4:
     resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
@@ -4284,14 +4179,6 @@ packages:
     dependencies:
       picomatch: 4.0.3
     dev: true
-
-  /fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-    dev: false
 
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -4444,14 +4331,6 @@ packages:
       for-in: 1.0.2
     dev: true
 
-  /foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-    dev: false
-
   /form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
@@ -4480,13 +4359,6 @@ packages:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
-
-  /formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
-    dependencies:
-      fetch-blob: 3.2.0
-    dev: false
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -4542,29 +4414,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  /gaxios@7.1.3:
-    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
-    engines: {node: '>=18'}
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6
-      node-fetch: 3.3.2
-      rimraf: 5.0.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
-    engines: {node: '>=18'}
-    dependencies:
-      gaxios: 7.1.3
-      google-logging-utils: 1.1.3
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -4677,19 +4526,6 @@ packages:
       - supports-color
     dev: true
 
-  /glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-    dev: false
-
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -4748,26 +4584,6 @@ packages:
       sparkles: 1.0.1
     dev: true
 
-  /google-auth-library@10.5.0:
-    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
-    engines: {node: '>=18'}
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.3
-      gcp-metadata: 8.1.2
-      google-logging-utils: 1.1.3
-      gtoken: 8.0.0
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /google-logging-utils@1.1.3:
-    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
-    engines: {node: '>=14'}
-    dev: false
-
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4793,16 +4609,6 @@ packages:
       web-streams-polyfill: 3.3.3
     transitivePeerDependencies:
       - encoding
-
-  /gtoken@8.0.0:
-    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
-    engines: {node: '>=18'}
-    dependencies:
-      gaxios: 7.1.3
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /guid-typescript@1.0.9:
     resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
@@ -4933,16 +4739,6 @@ packages:
       statuses: 2.0.2
       toidentifier: 1.0.1
     dev: true
-
-  /https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -5121,6 +4917,7 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+    dev: true
 
   /is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
@@ -5259,6 +5056,7 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
 
   /isobject@2.1.0:
     resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
@@ -5271,14 +5069,6 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-    dev: false
 
   /jmespath@0.16.0:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
@@ -5309,12 +5099,6 @@ packages:
     dependencies:
       argparse: 2.0.1
     dev: true
-
-  /json-bigint@1.0.0:
-    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
-    dependencies:
-      bignumber.js: 9.3.1
-    dev: false
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -5361,21 +5145,6 @@ packages:
   /just-debounce@1.1.0:
     resolution: {integrity: sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==}
     dev: true
-
-  /jwa@2.0.1:
-    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-    dev: false
-
-  /jws@4.0.1:
-    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
-    dependencies:
-      jwa: 2.0.1
-      safe-buffer: 5.2.1
-    dev: false
 
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -5428,31 +5197,6 @@ packages:
       - react-dom
       - zod-to-json-schema
     dev: true
-
-  /langsmith@0.3.87:
-    resolution: {integrity: sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==}
-    peerDependencies:
-      '@opentelemetry/api': '*'
-      '@opentelemetry/exporter-trace-otlp-proto': '*'
-      '@opentelemetry/sdk-trace-base': '*'
-      openai: '*'
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@opentelemetry/exporter-trace-otlp-proto':
-        optional: true
-      '@opentelemetry/sdk-trace-base':
-        optional: true
-      openai:
-        optional: true
-    dependencies:
-      '@types/uuid': 10.0.0
-      chalk: 4.1.2
-      console-table-printer: 2.15.0
-      p-queue: 6.6.2
-      semver: 7.7.3
-      uuid: 10.0.0
-    dev: false
 
   /langsmith@0.5.4(openai@4.104.0):
     resolution: {integrity: sha512-qYkNIoKpf0ZYt+cYzrDV+XI3FCexApmZmp8EMs3eDTMv0OvrHMLoxJ9IpkeoXJSX24+GPk0/jXjKx2hWerpy9w==}
@@ -5601,10 +5345,6 @@ packages:
     dependencies:
       tslib: 2.8.1
     dev: true
-
-  /lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-    dev: false
 
   /lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
@@ -5778,14 +5518,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.2
+    dev: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: false
-
-  /minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
     dev: false
 
   /mixin-deep@1.3.2:
@@ -5980,15 +5716,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-
-  /node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
-    dev: false
 
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -6266,14 +5993,6 @@ packages:
       p-timeout: 7.0.1
     dev: true
 
-  /p-retry@4.6.2:
-    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@types/retry': 0.12.0
-      retry: 0.13.1
-    dev: false
-
   /p-retry@7.1.1:
     resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
     engines: {node: '>=20'}
@@ -6291,10 +6010,6 @@ packages:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
     engines: {node: '>=20'}
     dev: true
-
-  /package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-    dev: false
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6370,6 +6085,7 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+    dev: true
 
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -6391,14 +6107,6 @@ packages:
     dependencies:
       path-root-regex: 0.1.2
     dev: true
-
-  /path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
-    dev: false
 
   /path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -6875,11 +6583,6 @@ packages:
     engines: {node: '>=0.12'}
     dev: true
 
-  /retry@0.13.1:
-    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
-    engines: {node: '>= 4'}
-    dev: false
-
   /reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -6892,13 +6595,6 @@ packages:
     dependencies:
       glob: 7.2.3
     dev: true
-
-  /rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
-    hasBin: true
-    dependencies:
-      glob: 10.5.0
-    dev: false
 
   /rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
@@ -7138,10 +6834,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
+    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
 
   /side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -7190,6 +6888,7 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+    dev: true
 
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -7378,15 +7077,7 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  /string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
-    dev: false
+    dev: true
 
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -7412,13 +7103,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-
-  /strip-ansi@7.1.2:
-    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
-    engines: {node: '>=12'}
-    dependencies:
-      ansi-regex: 6.2.2
-    dev: false
+    dev: true
 
   /strip-bom@2.0.0:
     resolution: {integrity: sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==}
@@ -8271,6 +7956,7 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
 
   /why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -8301,15 +7987,7 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  /wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.1.2
-    dev: false
+    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -8406,6 +8084,7 @@ packages:
       zod: ^3.25 || ^4
     dependencies:
       zod: 3.25.76
+    dev: true
 
   /zod-to-json-schema@3.25.1(zod@4.3.6):
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,9 @@ together = ["together>=0.2.0"]
 # Local inference providers (run your own models)
 # Note: Ollama doesn't need a Python package - just HTTP requests to localhost:11434
 # Install Ollama separately from: https://ollama.ai
-vllm = ["vllm>=0.2.0"]  # For running vLLM in-process (or use vLLM server via HTTP)
+vllm = [
+    "vllm>=0.14.1; python_version >= '3.10' and python_version < '3.14'"
+]  # For running vLLM in-process (or use vLLM server via HTTP)
 
 # Common API providers bundle (most popular)
 providers = [
@@ -78,7 +80,7 @@ providers = [
 
 # Local inference bundle
 local = [
-    "vllm>=0.2.0",
+    "vllm>=0.14.1; python_version >= '3.10' and python_version < '3.14'",
 ]
 
 # Semantic routing (optional feature)
@@ -120,7 +122,7 @@ all = [
     "groq>=0.4.0",
     "huggingface-hub>=0.19.0",
     "together>=0.2.0",
-    "vllm>=0.2.0",
+    "vllm>=0.14.1; python_version >= '3.10' and python_version < '3.14'",
     "sentence-transformers>=2.2.0",
     "fastembed>=0.7.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,8 @@ huggingface-hub>=0.19.0
 together>=0.2.0
 
 # Local inference (optional - can also use HTTP)
-vllm>=0.2.0
+# Security note: patched vLLM releases currently require Python >=3.10.
+vllm>=0.14.1; python_version >= "3.10" and python_version < "3.14"
 
 # Note: Ollama doesn't need a Python package - uses HTTP
 
@@ -105,6 +106,11 @@ types-requests>=2.31.0
 # Lightweight embedding model for semantic quality checks
 # Note: This is optional but required for semantic quality tests
 fastembed>=0.2.0
+
+# Transitive security floors (keep dev installs on patched versions)
+filelock>=3.20.3
+pillow>=12.1.1
+marshmallow>=4.1.2
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- harden CI security job to fail closed for core runtime deps and bandit scans
- remove vulnerable optional Vercel peer surface and upgrade n8n LangChain core line
- replace unsafe eval usage in examples/docs with strict parser helpers
- fix stale docs/security metadata (streaming extras, supported versions, vLLM python note)
- add non-breaking gateway warning for wildcard CORS on non-local bind hosts

## Validation
- python: black, ruff, mypy, pytest (non-integration)
- ts: core typecheck/examples + core tests
- integrations: vercel-ai, langchain, paygentic, n8n build/test/lint
- security: pnpm audit --prod, pip-audit requirements.txt, bandit -ll
