### PR TITLE
Harden ClawHub CascadeFlow skill metadata and safety guidance

### DIFF
--- a/examples/integrations/openclaw/cascadeflow-clawhub/SKILL.md
+++ b/examples/integrations/openclaw/cascadeflow-clawhub/SKILL.md
@@ -14,6 +14,14 @@ Use CascadeFlow as an OpenClaw provider to lower cost and latency via cascading.
 - Support cascading with streaming and multi-step agent loops.
 - Handle OpenClaw-native event/domain signals for smarter model selection.
 
+## Security Defaults
+
+- Install from PyPI and verify package metadata before first run.
+- Keep the server bound to localhost by default.
+- Use explicit auth tokens for chat and stats endpoints.
+- Expose remote access only behind TLS/reverse proxy with strong tokens.
+- Use least-privilege provider keys (separate test keys from production keys).
+
 ## How It Works
 
 1. OpenClaw sends requests to CascadeFlow through OpenAI-compatible `/v1/chat/completions`.
@@ -34,29 +42,31 @@ Use CascadeFlow as an OpenClaw provider to lower cost and latency via cascading.
 
 Or ask your OpenClaw agent to set it up for you as an OpenClaw custom provider with OpenClaw-native events and domain understanding.
 
-1. Install:
+1. Install and verify package source:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install "cascadeflow[openclaw]"
+python -m pip install --upgrade "cascadeflow[openclaw]>=0.7,<0.8"
+python -m pip show cascadeflow
 ```
 
 Optional variants:
 ```bash
-pip install "cascadeflow[openclaw,anthropic]"   # Anthropic-only preset
-pip install "cascadeflow[openclaw,openai]"      # OpenAI-only preset
-pip install "cascadeflow[openclaw,providers]"   # Mixed preset
+python -m pip install --upgrade "cascadeflow[openclaw,anthropic]>=0.7,<0.8"   # Anthropic-only preset
+python -m pip install --upgrade "cascadeflow[openclaw,openai]>=0.7,<0.8"      # OpenAI-only preset
+python -m pip install --upgrade "cascadeflow[openclaw,providers]>=0.7,<0.8"   # Mixed preset
 ```
 
-2. Pick preset + keys:
+2. Pick preset + required credentials:
 - Presets: `examples/configs/anthropic-only.yaml`, `examples/configs/openai-only.yaml`, `examples/configs/mixed-anthropic-openai.yaml`
-- `.env`: `ANTHROPIC_API_KEY=...` and/or `OPENAI_API_KEY=...`
+- Provider key(s): `ANTHROPIC_API_KEY=...` and/or `OPENAI_API_KEY=...`
+- Service tokens: `--auth-token ...` and `--stats-auth-token ...` (use long random values; examples below are placeholders)
 
-3. Start server:
+3. Start server (safe local default):
 ```bash
 set -a; source .env; set +a
 python3 -m cascadeflow.integrations.openclaw.openai_server \
-  --host <bind-host> --port 8084 \
+  --host 127.0.0.1 --port 8084 \
   --config examples/configs/anthropic-only.yaml \
   --auth-token local-openclaw-token \
   --stats-auth-token local-stats-token
@@ -67,6 +77,7 @@ python3 -m cascadeflow.integrations.openclaw.openai_server \
 - If remote: `http://<server-ip>:8084/v1` or `https://<domain>/v1` (TLS/reverse proxy)
 - `api`: `openai-completions`
 - `model`: `cascadeflow`
+- `apiKey`: same value as your `--auth-token`
 
 ## Commands
 
@@ -80,3 +91,4 @@ python3 -m cascadeflow.integrations.openclaw.openai_server \
 - Full setup + configs: `references/clawhub_publish_pack.md`
 - Listing strategy: `references/market_positioning.md`
 - Official docs: `https://github.com/lemony-ai/cascadeflow/blob/main/docs/guides/openclaw_provider.md`
+- GitHub repository: `https://github.com/lemony-ai/cascadeflow`

--- a/examples/integrations/openclaw/cascadeflow-clawhub/agents/openai.yaml
+++ b/examples/integrations/openclaw/cascadeflow-clawhub/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "CascadeFlow: Cost + Latency Reduction"
-  short_description: "Lower cost/latency via cascading, with streaming and agent loops"
-  default_prompt: "Use $cascadeflow to set up provider config, presets, and /model cflow with secure defaults."
+  short_description: "Cascading savings with OpenClaw-native routing"
+  default_prompt: "Use $cascadeflow to configure a secure localhost provider, required keys/tokens, and /model cflow."

--- a/examples/integrations/openclaw/cascadeflow-clawhub/references/clawhub_publish_pack.md
+++ b/examples/integrations/openclaw/cascadeflow-clawhub/references/clawhub_publish_pack.md
@@ -36,6 +36,18 @@ Result:
 - `folder`: `cascadeflow`
 - `slug`: `cascadeflow`
 - `display_name`: `CascadeFlow: Cost + Latency Reduction`
+- `source_url`: `https://github.com/lemony-ai/cascadeflow`
+- `homepage_url`: `https://github.com/lemony-ai/cascadeflow/blob/main/docs/guides/openclaw_provider.md`
+
+## Required Credentials (declare in listing)
+
+- `OPENAI_API_KEY` (when using OpenAI models/preset)
+- `ANTHROPIC_API_KEY` (when using Anthropic models/preset)
+- `CASCADEFLOW_AUTH_TOKEN` (maps to server `--auth-token`)
+- `CASCADEFLOW_STATS_AUTH_TOKEN` (maps to server `--stats-auth-token`)
+
+Do not leave credential requirements empty in listing metadata.
+Use strong random token values in production (examples in this file are placeholders).
 
 ## Upload Folder
 
@@ -57,20 +69,21 @@ Fastest base setup (OpenClaw integration extras):
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install "cascadeflow[openclaw]"
+python -m pip install --upgrade "cascadeflow[openclaw]>=0.7,<0.8"
+python -m pip show cascadeflow
 ```
 
 Quick provider variants:
 
 ```bash
 # Anthropic-only preset users
-pip install "cascadeflow[openclaw,anthropic]"
+python -m pip install --upgrade "cascadeflow[openclaw,anthropic]>=0.7,<0.8"
 
 # OpenAI-only preset users
-pip install "cascadeflow[openclaw,openai]"
+python -m pip install --upgrade "cascadeflow[openclaw,openai]>=0.7,<0.8"
 
 # Mixed preset users (OpenAI + Anthropic + common providers)
-pip install "cascadeflow[openclaw,providers]"
+python -m pip install --upgrade "cascadeflow[openclaw,providers]>=0.7,<0.8"
 ```
 
 ## 2) Pick A Preset Config (All 3)
@@ -105,7 +118,7 @@ Use only keys required by the selected preset.
 ```bash
 set -a; source .env; set +a
 python3 -m cascadeflow.integrations.openclaw.openai_server \
-  --host <bind-host> \
+  --host 127.0.0.1 \
   --port 8084 \
   --config examples/configs/anthropic-only.yaml \
   --auth-token local-openclaw-token \
@@ -156,11 +169,12 @@ nohup cascadeflow-gateway --port 8084 --mode agent --config examples/configs/ant
 ```
 
 Host notes:
-- If OpenClaw and CascadeFlow run on the same machine, use `127.0.0.1`.
+- If OpenClaw and CascadeFlow run on the same machine, keep `127.0.0.1`.
 - If CascadeFlow runs on another machine, use that server IP or domain.
 
 If server runs elsewhere, users should replace it with their host/IP, e.g.:
 - `http://<server-ip>:8084/v1` or `https://<domain>/v1` (behind proxy/TLS).
+- Keep `apiKey` equal to the server auth token value.
 
 ## 6) Create OpenClaw Agent
 


### PR DESCRIPTION
## Summary\n- clarify required credentials and listing metadata for ClawHub publish flow\n- add explicit security defaults (localhost bind, strong tokens, TLS/reverse-proxy for remote exposure)\n- update install snippets to version-scoped PyPI install plus package verification\n- add direct GitHub repo link at bottom of skill docs\n\n## Why\nClawHub feedback highlighted metadata/provenance ambiguity and network-service risk cues. This aligns the skill docs with safer defaults and clearer operational requirements.