### PR TITLE
Clarify ClawHub skill credential metadata and package verification

### DIFF
--- a/examples/integrations/openclaw/cascadeflow-clawhub/SKILL.md
+++ b/examples/integrations/openclaw/cascadeflow-clawhub/SKILL.md
@@ -16,9 +16,9 @@ Use CascadeFlow as an OpenClaw provider to lower cost and latency via cascading.
 
 ## Security Defaults
 
-- Install from PyPI and verify package metadata before first run.
+- Install from PyPI and verify package artifact before first run.
 - Keep the server bound to localhost by default.
-- Use explicit auth tokens for chat and stats endpoints.
+- Use explicit auth tokens for chat and stats endpoints (recommended for production).
 - Expose remote access only behind TLS/reverse proxy with strong tokens.
 - Use least-privilege provider keys (separate test keys from production keys).
 
@@ -48,6 +48,8 @@ python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade "cascadeflow[openclaw]>=0.7,<0.8"
 python -m pip show cascadeflow
+python -m pip download --no-deps "cascadeflow[openclaw]>=0.7,<0.8" -d /tmp/cascadeflow_pkg
+python -m pip hash /tmp/cascadeflow_pkg/cascadeflow-*.whl
 ```
 
 Optional variants:
@@ -57,10 +59,10 @@ python -m pip install --upgrade "cascadeflow[openclaw,openai]>=0.7,<0.8"      # 
 python -m pip install --upgrade "cascadeflow[openclaw,providers]>=0.7,<0.8"   # Mixed preset
 ```
 
-2. Pick preset + required credentials:
+2. Pick preset + credentials:
 - Presets: `examples/configs/anthropic-only.yaml`, `examples/configs/openai-only.yaml`, `examples/configs/mixed-anthropic-openai.yaml`
-- Provider key(s): `ANTHROPIC_API_KEY=...` and/or `OPENAI_API_KEY=...`
-- Service tokens: `--auth-token ...` and `--stats-auth-token ...` (use long random values; examples below are placeholders)
+- Provider key(s): `ANTHROPIC_API_KEY=...` and/or `OPENAI_API_KEY=...` (required based on selected preset)
+- Service tokens: `--auth-token ...` and `--stats-auth-token ...` (recommended for production; use long random values)
 
 3. Start server (safe local default):
 ```bash

--- a/examples/integrations/openclaw/cascadeflow-clawhub/references/clawhub_publish_pack.md
+++ b/examples/integrations/openclaw/cascadeflow-clawhub/references/clawhub_publish_pack.md
@@ -39,12 +39,12 @@ Result:
 - `source_url`: `https://github.com/lemony-ai/cascadeflow`
 - `homepage_url`: `https://github.com/lemony-ai/cascadeflow/blob/main/docs/guides/openclaw_provider.md`
 
-## Required Credentials (declare in listing)
+## Credentials To Declare In Listing
 
-- `OPENAI_API_KEY` (when using OpenAI models/preset)
-- `ANTHROPIC_API_KEY` (when using Anthropic models/preset)
-- `CASCADEFLOW_AUTH_TOKEN` (maps to server `--auth-token`)
-- `CASCADEFLOW_STATS_AUTH_TOKEN` (maps to server `--stats-auth-token`)
+- `OPENAI_API_KEY` (required when using OpenAI models/preset)
+- `ANTHROPIC_API_KEY` (required when using Anthropic models/preset)
+- `CASCADEFLOW_AUTH_TOKEN` (recommended in production; maps to server `--auth-token`)
+- `CASCADEFLOW_STATS_AUTH_TOKEN` (optional separate stats token; maps to server `--stats-auth-token`)
 
 Do not leave credential requirements empty in listing metadata.
 Use strong random token values in production (examples in this file are placeholders).
@@ -71,6 +71,8 @@ python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade "cascadeflow[openclaw]>=0.7,<0.8"
 python -m pip show cascadeflow
+python -m pip download --no-deps "cascadeflow[openclaw]>=0.7,<0.8" -d /tmp/cascadeflow_pkg
+python -m pip hash /tmp/cascadeflow_pkg/cascadeflow-*.whl
 ```
 
 Quick provider variants:


### PR DESCRIPTION
## Summary\n- add explicit pip artifact verification steps ( + )\n- clarify required vs recommended/optional credentials in publish pack\n- align quickstart wording in SKILL.md with listing transparency concerns\n\n## Why\nThis addresses ClawHub trust feedback about metadata clarity and verification guidance without changing runtime behavior.