### PR TITLE
feat(openclaw): add opt-in harness mode toggle for provider server

### DIFF
--- a/cascadeflow/integrations/openclaw/openai_server.py
+++ b/cascadeflow/integrations/openclaw/openai_server.py
@@ -1294,6 +1294,39 @@ def _build_openai_response(model: str, result) -> dict[str, Any]:
 __all__ = ["OpenClawOpenAIServer", "OpenClawOpenAIConfig"]
 
 
+def _format_harness_summary(config: Any) -> str:
+    parts = [f"mode={config.mode}"]
+    if config.budget is not None:
+        parts.append(f"budget={config.budget}")
+    if config.max_tool_calls is not None:
+        parts.append(f"max_tool_calls={config.max_tool_calls}")
+    if config.max_latency_ms is not None:
+        parts.append(f"max_latency_ms={config.max_latency_ms}")
+    if config.max_energy is not None:
+        parts.append(f"max_energy={config.max_energy}")
+    if config.compliance:
+        parts.append(f"compliance={config.compliance}")
+    return " ".join(parts)
+
+
+def _configure_harness(args: Any) -> None:
+    from cascadeflow.harness import get_harness_config, init
+
+    harness_kwargs = {
+        "mode": args.harness_mode,
+        "budget": args.harness_budget,
+        "max_tool_calls": args.harness_max_tool_calls,
+        "max_latency_ms": args.harness_max_latency_ms,
+        "max_energy": args.harness_max_energy,
+        "compliance": args.harness_compliance,
+    }
+    init(**harness_kwargs)
+
+    resolved = get_harness_config()
+    if resolved.mode != "off" or any(value is not None for value in harness_kwargs.values()):
+        print(f"Harness {_format_harness_summary(resolved)}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="OpenClaw OpenAI-compatible server")
     parser.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
@@ -1362,12 +1395,49 @@ def main() -> None:
         default=None,
         help="Directory to serve static files from (e.g. install.sh).",
     )
+    parser.add_argument(
+        "--harness-mode",
+        choices=["off", "observe", "enforce"],
+        default=None,
+        help="Optional harness mode override (off|observe|enforce).",
+    )
+    parser.add_argument(
+        "--harness-budget",
+        type=float,
+        default=None,
+        help="Optional harness budget cap in USD.",
+    )
+    parser.add_argument(
+        "--harness-max-tool-calls",
+        type=int,
+        default=None,
+        help="Optional harness cap for tool calls per run.",
+    )
+    parser.add_argument(
+        "--harness-max-latency-ms",
+        type=float,
+        default=None,
+        help="Optional harness latency cap in milliseconds.",
+    )
+    parser.add_argument(
+        "--harness-max-energy",
+        type=float,
+        default=None,
+        help="Optional harness energy cap (normalized units).",
+    )
+    parser.add_argument(
+        "--harness-compliance",
+        choices=["gdpr", "hipaa", "pci", "strict"],
+        default=None,
+        help="Optional harness compliance policy.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
+    _configure_harness(args)
 
     if args.config:
         from cascadeflow.config_loader import load_agent

--- a/docs-site/integrations/openclaw.mdx
+++ b/docs-site/integrations/openclaw.mdx
@@ -14,6 +14,24 @@ OpenClaw can call cascadeflow through an OpenAI-compatible interface. That makes
 1. Start the cascadeflow OpenAI-compatible server.
 2. Point OpenClaw at that base URL as a custom provider.
 3. Optionally pass routing hints, tenant metadata, or channel information.
+4. Optionally enable harness mode for in-loop runtime policy decisions.
+
+## Optional Harness Toggle
+
+OpenClaw integration stays compatibility-first, but you can opt into harness behavior
+at server startup:
+
+- `--harness-mode off` (default)
+- `--harness-mode observe` (recommended first step)
+- `--harness-mode enforce` (active controls with budgets/limits)
+
+Example:
+
+```bash
+python -m cascadeflow.integrations.openclaw.openai_server \
+  --port 8084 \
+  --harness-mode observe
+```
 
 ## Why Teams Use It
 

--- a/docs/guides/openclaw_provider.md
+++ b/docs/guides/openclaw_provider.md
@@ -15,6 +15,40 @@ Common options:
 - `--config /path/to/cascadeflow.yaml` (override models + channels via config file)
 - `--no-classifier` to disable the OpenClaw pre-router classifier
 - `--no-stream` to disable streaming responses
+- `--harness-mode off|observe|enforce` to control in-loop harness policy behavior
+- `--harness-budget`, `--harness-max-tool-calls`, `--harness-max-latency-ms`, `--harness-compliance` for optional limits
+
+## 1b) Optional: enable in-loop harness controls
+
+`--harness-mode` is opt-in. Use it when you want runtime policy actions inside the
+Cascadeflow execution loop for OpenClaw traffic.
+
+- `off`: compatibility mode only (default)
+- `observe`: log and trace decisions without blocking
+- `enforce`: apply actions (for example switch model, deny tool, stop)
+
+Start in observe mode (recommended):
+
+```bash
+python -m cascadeflow.integrations.openclaw.openai_server \
+  --port 8084 \
+  --harness-mode observe
+```
+
+Move to enforce mode with limits:
+
+```bash
+python -m cascadeflow.integrations.openclaw.openai_server \
+  --port 8084 \
+  --harness-mode enforce \
+  --harness-budget 1.0 \
+  --harness-max-tool-calls 12 \
+  --harness-max-latency-ms 3500 \
+  --harness-compliance strict
+```
+
+On startup, the server prints the resolved harness settings so you can verify the
+active mode immediately.
 
 ## 2) Configure OpenClaw custom provider
 

--- a/examples/integrations/openclaw/cascadeflow-clawhub/SKILL.md
+++ b/examples/integrations/openclaw/cascadeflow-clawhub/SKILL.md
@@ -74,6 +74,25 @@ python3 -m cascadeflow.integrations.openclaw.openai_server \
   --stats-auth-token local-stats-token
 ```
 
+Optional harness activation (runtime in-loop policy controls):
+```bash
+# Observe first (recommended): log decisions, no blocking
+python3 -m cascadeflow.integrations.openclaw.openai_server \
+  --host 127.0.0.1 --port 8084 \
+  --config examples/configs/anthropic-only.yaml \
+  --harness-mode observe
+
+# Enforce mode with limits
+python3 -m cascadeflow.integrations.openclaw.openai_server \
+  --host 127.0.0.1 --port 8084 \
+  --config examples/configs/anthropic-only.yaml \
+  --harness-mode enforce \
+  --harness-budget 1.0 \
+  --harness-max-tool-calls 12 \
+  --harness-max-latency-ms 3500 \
+  --harness-compliance strict
+```
+
 4. Configure OpenClaw provider:
 - `baseUrl`: `http://<cascadeflow-host>:8084/v1` (local default: `http://127.0.0.1:8084/v1`)
 - If remote: `http://<server-ip>:8084/v1` or `https://<domain>/v1` (TLS/reverse proxy)

--- a/tests/test_openclaw_harness_cli.py
+++ b/tests/test_openclaw_harness_cli.py
@@ -1,0 +1,84 @@
+from argparse import Namespace
+
+from cascadeflow.harness import HarnessConfig
+from cascadeflow.integrations.openclaw.openai_server import _configure_harness
+
+
+def _args(**overrides):
+    base = {
+        "harness_mode": None,
+        "harness_budget": None,
+        "harness_max_tool_calls": None,
+        "harness_max_latency_ms": None,
+        "harness_max_energy": None,
+        "harness_compliance": None,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_configure_harness_passes_cli_values(monkeypatch, capsys):
+    captured = {}
+
+    def fake_init(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("cascadeflow.harness.init", fake_init)
+    monkeypatch.setattr(
+        "cascadeflow.harness.get_harness_config",
+        lambda: HarnessConfig(
+            mode="observe",
+            budget=1.0,
+            max_tool_calls=12,
+            max_latency_ms=3500,
+            compliance="strict",
+        ),
+    )
+
+    _configure_harness(
+        _args(
+            harness_mode="observe",
+            harness_budget=1.0,
+            harness_max_tool_calls=12,
+            harness_max_latency_ms=3500,
+            harness_compliance="strict",
+        )
+    )
+
+    assert captured == {
+        "mode": "observe",
+        "budget": 1.0,
+        "max_tool_calls": 12,
+        "max_latency_ms": 3500,
+        "max_energy": None,
+        "compliance": "strict",
+    }
+    output = capsys.readouterr().out
+    assert "Harness mode=observe" in output
+    assert "budget=1.0" in output
+    assert "max_tool_calls=12" in output
+
+
+def test_configure_harness_no_flags_off_mode_is_quiet(monkeypatch, capsys):
+    monkeypatch.setattr("cascadeflow.harness.init", lambda **_: None)
+    monkeypatch.setattr(
+        "cascadeflow.harness.get_harness_config",
+        lambda: HarnessConfig(mode="off"),
+    )
+
+    _configure_harness(_args())
+
+    assert capsys.readouterr().out == ""
+
+
+def test_configure_harness_explicit_off_prints_status(monkeypatch, capsys):
+    monkeypatch.setattr("cascadeflow.harness.init", lambda **_: None)
+    monkeypatch.setattr(
+        "cascadeflow.harness.get_harness_config",
+        lambda: HarnessConfig(mode="off"),
+    )
+
+    _configure_harness(_args(harness_mode="off"))
+
+    output = capsys.readouterr().out
+    assert "Harness mode=off" in output


### PR DESCRIPTION
## Summary
- add OpenClaw server CLI flags for optional harness activation: `--harness-mode off|observe|enforce`
- add optional harness limits: `--harness-budget`, `--harness-max-tool-calls`, `--harness-max-latency-ms`, `--harness-max-energy`, `--harness-compliance`
- initialize harness at OpenClaw server startup and print effective harness status when explicitly enabled
- document activation paths in OpenClaw guide, docs-site integration page, and ClawHub skill quickstart
- add focused tests for OpenClaw CLI -> harness wiring

## Scope
OpenClaw integration-level only (server + integration docs + integration skill + integration tests). No core harness/routing behavior changes.

## Validation
- `python3 -m ruff check ./cascadeflow/integrations/openclaw/openai_server.py ./tests/test_openclaw_harness_cli.py`
- `python3 -m pytest tests/test_openclaw_harness_cli.py tests/test_openclaw_openai_server_auth.py tests/test_openclaw_openai_server_streaming.py tests/test_openclaw_demo_mode.py tests/test_openclaw_upstream_errors.py`

Both passed locally.
