### PR TITLE
docs: add cascadeflow vs LiteLLM comparison

### DIFF
--- a/docs-site/comparisons/litellm.mdx
+++ b/docs-site/comparisons/litellm.mdx
@@ -10,7 +10,7 @@ description: "cascadeflow is an in-process runtime intelligence layer for agent 
 |---------|------------|---------|
 | **Architecture** | In-process library | Reverse proxy (separate service) |
 | **Deployment** | `pip install cascadeflow` | Standalone server or library |
-| **Latency overhead** | Typically <5ms | Typically 10-50ms (HTTP RTT) |
+| **Latency overhead** | Typically &lt;5ms | Typically 10-50ms (HTTP RTT) |
 | **Optimization dimensions** | 6 (cost, latency, quality, budget, compliance, energy) | 1 (cost-based routing) |
 | **Quality validation** | 5+ validators built-in | None |
 | **Enforcement actions** | allow / switch / deny / stop | None |
@@ -45,7 +45,7 @@ Your App
 ```
 
 This difference affects:
-- **Latency**: cascadeflow typically adds <5ms; LiteLLM adds network round-trip time
+- **Latency**: cascadeflow typically adds &lt;5ms; LiteLLM adds network round-trip time
 - **Visibility**: cascadeflow sees tool calls, agent state, execution context; LiteLLM sees only API calls
 - **Coupling**: cascadeflow is tightly integrated; LiteLLM is loosely coupled
 


### PR DESCRIPTION
## 🎯 Description
Add comparison page: cascadeflow vs LiteLLM. Covers architecture differences (in-process harness vs reverse proxy), latency comparison, multi-dimensional optimization vs cost-only routing, enforcement actions, and when to use each tool together. Includes code examples in Python and TypeScript.

## 🔗 Related Issues
- Related to documentation expansion for docs.cascadeflow.dev

## 🔄 Type of Change
- [x] 📝 Documentation update

## 🧪 Testing
### Test cases added
- [x] Manual testing

### How to test
Preview the page on docs.cascadeflow.dev/comparisons/litellm after merge.

## 📋 Checklist
### Documentation
- [x] I have updated relevant documentation
- [ ] ~~I have updated the README if needed~~ N/A
- [ ] ~~I have added docstrings to new functions/classes~~ N/A
- [ ] ~~I have updated the CHANGELOG.md (if applicable)~~ N/A
- [ ] ~~I have added examples if this is a new feature~~ N/A

### Dependencies
- [x] This PR includes NO new dependencies

### Breaking Changes
- [x] This PR includes NO breaking changes

### Performance
- [x] No performance impact (documentation only)

## 🔐 Security Considerations
- [x] This PR does not introduce security vulnerabilities
- [x] I have not exposed sensitive information (API keys, credentials, etc.)

## 📝 Additional Notes
New file: `docs-site/comparisons/litellm.mdx`
Navigation update for this page will be added in a separate PR after all comparison pages are merged.

---
**By submitting this PR, I confirm that:**
- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My contribution is my own original work or properly attributed
- [x] I agree to license my contribution under the project's MIT license
- [x] I have tested my changes thoroughly