### PR TITLE
fix: allow deepseek and openrouter providers in ModelConfig validation

### DIFF
--- a/cascadeflow/schema/config.py
+++ b/cascadeflow/schema/config.py
@@ -111,12 +111,14 @@ class ModelConfig(BaseModel):
         allowed = [
             "openai",
             "anthropic",
+            "deepseek",
             "groq",
             "ollama",
             "huggingface",
             "together",
             "vllm",
             "replicate",
+            "openrouter",
             "custom",
         ]
         if v not in allowed:

--- a/tests/test_model_config_provider_validation.py
+++ b/tests/test_model_config_provider_validation.py
@@ -1,0 +1,29 @@
+import pytest
+
+from cascadeflow.config import ModelConfig
+from cascadeflow.providers.base import PROVIDER_CAPABILITIES
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        "deepseek",
+        "DeepSeek",
+        "openrouter",
+        "OpenRouter",
+    ],
+)
+def test_model_config_provider_allows_supported_providers(provider: str) -> None:
+    config = ModelConfig(name="x", provider=provider, cost=0.0)
+    assert config.provider == provider.lower()
+
+
+def test_model_config_provider_rejects_unknown_provider() -> None:
+    with pytest.raises(ValueError, match="Provider must be one of"):
+        ModelConfig(name="x", provider="unknown_provider", cost=0.0)
+
+
+def test_model_config_provider_allows_all_provider_capability_keys() -> None:
+    for provider in PROVIDER_CAPABILITIES:
+        config = ModelConfig(name="x", provider=provider, cost=0.0)
+        assert config.provider == provider


### PR DESCRIPTION
## Description
Fix inconsistency in `ModelConfig.validate_provider()` where supported providers (`deepseek`, `openrouter`) were rejected during validation.

The allow-list in schema validation did not include these providers, even though they are supported in provider capabilities, registry, and used in examples. This caused valid user configurations to fail.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement

## Testing
- [x] Tests pass locally (6/6 new tests passed)
- [x] Added new tests
- [ ] Updated documentation
- [x] Ran formatting script

### Test Results
```bash
pytest -o addopts= tests/test_model_config_provider_validation.py -v