### PR TITLE
feat(integrations): add Hermes delegation router

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 <br>
 
-**[<img src=".github/assets/CF_python_color.svg" width="22" height="22" alt="Python" style="vertical-align: middle;"/> Python](https://docs.cascadeflow.ai/api-reference/python/overview) • [<img src=".github/assets/CF_ts_color.svg" width="22" height="22" alt="TypeScript" style="vertical-align: middle;"/> TypeScript](https://docs.cascadeflow.ai/api-reference/typescript/overview) • [<picture><source media="(prefers-color-scheme: dark)" srcset="./.github/assets/LC-logo-bright.png"><source media="(prefers-color-scheme: light)" srcset="./.github/assets/LC-logo-dark.png"><img src=".github/assets/LC-logo-dark.png" height="22" alt="LangChain" style="vertical-align: middle;"></picture> LangChain](https://docs.cascadeflow.ai/integrations/langchain) • [<img src=".github/assets/CF_openai_color.svg" width="22" height="22" alt="OpenAI" style="vertical-align: middle;"/> OpenAI Agents](https://docs.cascadeflow.ai/integrations/openai-agents) • [<img src=".github/assets/CF_crewai_color.svg" width="22" height="22" alt="CrewAI" style="vertical-align: middle;"/> CrewAI](https://docs.cascadeflow.ai/integrations/crewai) • [<img src=".github/assets/CF_pydantic_color.svg" width="22" height="22" alt="PydanticAI" style="vertical-align: middle;"/> PydanticAI](https://docs.cascadeflow.ai/integrations/pydantic-ai) • [<img src=".github/assets/CF_google_adk_color.svg" width="22" height="22" alt="Google ADK" style="vertical-align: middle;"/> Google ADK](https://docs.cascadeflow.ai/integrations/google-adk) • [<img src=".github/assets/CF_n8n_color.svg" width="22" height="22" alt="n8n" style="vertical-align: middle;"/> n8n](https://docs.cascadeflow.ai/integrations/n8n) • [<picture><source media="(prefers-color-scheme: dark)" srcset="./.github/assets/CF_vercel_bright.svg"><source media="(prefers-color-scheme: light)" srcset="./.github/assets/CF_vercel_dark.svg"><img src=".github/assets/CF_vercel_dark.svg" width="22" height="22" alt="Vercel AI" style="vertical-align: middle;"></picture> Vercel AI](https://docs.cascadeflow.ai/integrations/vercel-ai) • [<img src=".github/assets/CF_openclaw_color.svg" width="22" height="22" alt="OpenClaw" style="vertical-align: middle;"/> OpenClaw](https://docs.cascadeflow.ai/integrations/openclaw) • [📖&nbsp;Docs](https://docs.cascadeflow.ai) • [💡&nbsp;Examples](#examples)**
+**[<img src=".github/assets/CF_python_color.svg" width="22" height="22" alt="Python" style="vertical-align: middle;"/> Python](https://docs.cascadeflow.ai/api-reference/python/overview) • [<img src=".github/assets/CF_ts_color.svg" width="22" height="22" alt="TypeScript" style="vertical-align: middle;"/> TypeScript](https://docs.cascadeflow.ai/api-reference/typescript/overview) • [<picture><source media="(prefers-color-scheme: dark)" srcset="./.github/assets/LC-logo-bright.png"><source media="(prefers-color-scheme: light)" srcset="./.github/assets/LC-logo-dark.png"><img src=".github/assets/LC-logo-dark.png" height="22" alt="LangChain" style="vertical-align: middle;"></picture> LangChain](https://docs.cascadeflow.ai/integrations/langchain) • [<img src=".github/assets/CF_openai_color.svg" width="22" height="22" alt="OpenAI" style="vertical-align: middle;"/> OpenAI Agents](https://docs.cascadeflow.ai/integrations/openai-agents) • [<img src=".github/assets/CF_crewai_color.svg" width="22" height="22" alt="CrewAI" style="vertical-align: middle;"/> CrewAI](https://docs.cascadeflow.ai/integrations/crewai) • [<img src=".github/assets/CF_pydantic_color.svg" width="22" height="22" alt="PydanticAI" style="vertical-align: middle;"/> PydanticAI](https://docs.cascadeflow.ai/integrations/pydantic-ai) • [<img src=".github/assets/CF_google_adk_color.svg" width="22" height="22" alt="Google ADK" style="vertical-align: middle;"/> Google ADK](https://docs.cascadeflow.ai/integrations/google-adk) • [<img src=".github/assets/CF_n8n_color.svg" width="22" height="22" alt="n8n" style="vertical-align: middle;"/> n8n](https://docs.cascadeflow.ai/integrations/n8n) • [<picture><source media="(prefers-color-scheme: dark)" srcset="./.github/assets/CF_vercel_bright.svg"><source media="(prefers-color-scheme: light)" srcset="./.github/assets/CF_vercel_dark.svg"><img src=".github/assets/CF_vercel_dark.svg" width="22" height="22" alt="Vercel AI" style="vertical-align: middle;"></picture> Vercel AI](https://docs.cascadeflow.ai/integrations/vercel-ai) • [<img src=".github/assets/CF_openclaw_color.svg" width="22" height="22" alt="OpenClaw" style="vertical-align: middle;"/> OpenClaw](https://docs.cascadeflow.ai/integrations/openclaw) • [Hermes Agent](https://docs.cascadeflow.ai/integrations/hermes-agent) • [📖&nbsp;Docs](https://docs.cascadeflow.ai) • [💡&nbsp;Examples](#examples)**
 
 </div>
 
@@ -37,7 +37,9 @@
 
 **The in-process intelligence layer for AI agents.** Optimize cost, latency, quality, budget, compliance, and energy — inside the execution loop, not at the HTTP boundary.
 
-cascadeflow works where external proxies can't: per-step model decisions based on agent state, per-tool-call budget gating, runtime stop/continue/escalate actions, and business KPI injection during agent loops. It accumulates insight from every model call, tool result, and quality score — the agent gets smarter the more it runs. Sub-5ms overhead. Works with LangChain, OpenAI Agents SDK, CrewAI, PydanticAI, Google ADK, n8n, and Vercel AI SDK.
+cascadeflow works where external proxies can't: per-step model decisions based on agent state, per-tool-call budget gating, runtime stop/continue/escalate actions, and business KPI injection during agent loops. It accumulates insight from every model call, tool result, and quality score — the agent gets smarter the more it runs. Sub-5ms overhead. Works with LangChain, OpenAI Agents SDK, CrewAI, PydanticAI, Google ADK, n8n, Vercel AI SDK, and Hermes Agent.
+
+**New: Hermes Agent delegation routing.** CascadeFlow now provides a Hermes Agent integration for per-skill model routing, task-complexity routing, topic-aware subagent routing, observe-mode rollout, and auditable decisions without taking over provider credentials, base URLs, fallback chains, or API modes. It is built as an optional integration surface, like n8n or Vercel AI SDK, so Hermes can keep its core runtime behavior while CascadeFlow supplies routing intelligence.
 
 ```bash
 pip install cascadeflow
@@ -74,7 +76,7 @@ cascadeflow is a **library** and **agent harness** — an intelligent AI model c
 - **Auditability & Transparency.** Every runtime decision is traceable and attributable. Supports audit requirements, faster tuning cycles, and trust in regulated or high-stakes workflows.
 - **Measurable Value.** Prove impact with reproducible metrics on realistic agent workflows — better economics and latency while preserving quality thresholds.
 - **Latency Advantage.** Proxy-based optimization adds 40-60ms per call. In a 10-step agent loop, that is 400-600ms of avoidable overhead. cascadeflow runs in-process with sub-5ms overhead — critical for real-time UX, task throughput, and enterprise SLAs.
-- **Framework & Provider Neutral.** Works with LangChain, OpenAI Agents SDK, CrewAI, PydanticAI, Google ADK, Vercel AI SDK, n8n, and custom frameworks. Unified API across OpenAI, Anthropic, Groq, Ollama, vLLM, Together, and more.
+- **Framework & Provider Neutral.** Works with LangChain, OpenAI Agents SDK, CrewAI, PydanticAI, Google ADK, Vercel AI SDK, n8n, Hermes Agent, and custom frameworks. Unified API across OpenAI, Anthropic, Groq, Ollama, vLLM, Together, and more.
 - **Self-Improving Agent Intelligence.** Because cascadeflow runs inside the agent loop, it accumulates deep insight into every model call, tool result, quality score, and routing decision over time. This enables cascadeflow to learn which models perform best for which tasks, adapt routing strategies, and continuously improve cost-quality tradeoffs — without manual tuning. The agent gets smarter the more it runs.
 - **Edge & Local-Hosted AI.** Handle most queries with local models (vLLM, Ollama), automatically escalate complex queries to cloud providers only when needed.
 
@@ -197,7 +199,7 @@ from cascadeflow import CascadeAgent, ModelConfig
 
 # Define your cascade - try cheap model first, escalate if needed
 agent = CascadeAgent(models=[
-    ModelConfig(name="gpt-4o-mini", provider="openai", cost=0.000375),  # Draft model (~$0.375/1M tokens)
+    ModelConfig(name="nous/hermes-flash", provider="openai", cost=0.000375),  # Draft model (~$0.375/1M tokens)
     ModelConfig(name="gpt-5", provider="openai", cost=0.00562),         # Verifier model (~$5.62/1M tokens)
 ])
 
@@ -270,7 +272,7 @@ import { CascadeAgent, ModelConfig } from '@cascadeflow/core';
 // Same API as Python!
 const agent = new CascadeAgent({
   models: [
-    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.000375 },
+    { name: 'nous/hermes-flash', provider: 'openai', cost: 0.000375 },
     { name: 'gpt-4o', provider: 'openai', cost: 0.00625 },
   ],
 });
@@ -299,7 +301,7 @@ import { CascadeAgent, SemanticQualityChecker } from '@cascadeflow/core';
 
 const agent = new CascadeAgent({
   models: [
-    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.000375 },
+    { name: 'nous/hermes-flash', provider: 'openai', cost: 0.000375 },
     { name: 'gpt-4o', provider: 'openai', cost: 0.00625 },
   ],
   quality: {
@@ -370,7 +372,7 @@ Cost: $0.000007, Latency: 234ms
 
 ```python
 agent = CascadeAgent(models=[
-    ModelConfig(name="gpt-4o-mini", provider="openai", cost=0.000375),
+    ModelConfig(name="nous/hermes-flash", provider="openai", cost=0.000375),
     ModelConfig(name="gpt-4o", provider="openai", cost=0.00625),
 ])
 
@@ -441,6 +443,64 @@ Use cascadeflow in n8n workflows for no-code AI automation with automatic cost o
 
 ---
 
+<details open>
+<summary><b>Hermes Agent Integration</b></summary>
+
+Use CascadeFlow as an optional Hermes Agent delegation router for subagents. Hermes keeps provider credentials, base URLs, fallback chains, and API modes; CascadeFlow returns a structured routing decision before Hermes spawns a child agent.
+
+This works as a released CascadeFlow module even before a native Hermes PR is accepted. Users can call the router from a local wrapper, local Hermes fork, or small hook script and keep Hermes' current provider configuration as the final source of truth.
+
+```python
+from cascadeflow.integrations.hermes import (
+    HermesDelegationRequest,
+    HermesDelegationRouter,
+)
+
+router = HermesDelegationRouter.from_dict({
+    "enabled": True,
+    "mode": "observe",
+    "routes": {
+        "code": {
+            "provider": "nous",
+            "model": "nous/hermes-4.1",
+            "reasoning_effort": "high",
+        },
+        "simple": {
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "reasoning_effort": "low",
+        },
+    },
+})
+
+decision = router.route_delegation(HermesDelegationRequest(
+    goal="Debug the failing unit test and propose a patch",
+    toolsets=("terminal", "git"),
+    loaded_skills=("python", "debugging"),
+))
+print(decision.to_dict())
+```
+
+**What Hermes gets:**
+
+- **Per-skill model routing:** coding, research, legal/finance, and lightweight utility skills can receive different model and reasoning profiles instead of inheriting one global default.
+- **Task-complexity routing:** simple delegated tasks can use cheaper/faster models, while hard debugging, architecture, research, or code-generation tasks route to stronger models.
+- **Topic-aware subagent routing:** subagents can route differently for code, research, data, creative, ops, medical, legal, finance, and other domains.
+- **Better subagent economics:** Hermes avoids paying flagship-model prices for simple worker tasks.
+- **Better quality for hard tasks:** difficult subagent work no longer has to inherit a weak or cheap default model.
+- **Dry-run/observe mode:** Hermes users can see what CascadeFlow would route without changing runtime behavior.
+- **Auditability:** routing decisions include reason, confidence, domain, complexity, and selected model.
+- **Safer rollout:** missing CascadeFlow, disabled config, low confidence, high-stakes gaps, or bad routing inputs fall back to Hermes' current behavior.
+- **No credential rewrite:** Hermes still owns provider credentials, base URLs, fallback chains, and API modes.
+
+**Learn more:** [Hermes Agent Integration Guide](https://docs.cascadeflow.ai/integrations/hermes-agent)
+
+**Standalone example:** [examples/integrations/hermes_delegation_router.py](./examples/integrations/hermes_delegation_router.py)
+
+</details>
+
+---
+
 <details>
 <summary><b><picture><source media="(prefers-color-scheme: dark)" srcset="./.github/assets/LC-logo-bright.png"><source media="(prefers-color-scheme: light)" srcset="./.github/assets/LC-logo-dark.png"><img src="./.github/assets/LC-logo-dark.png" width="42" alt="LangChain" style="vertical-align: middle;"></picture> LangChain Integration</b></summary>
 
@@ -471,7 +531,7 @@ import { ChatAnthropic } from '@langchain/anthropic';
 import { withCascade } from '@cascadeflow/langchain';
 
 const cascade = withCascade({
-  drafter: new ChatOpenAI({ model: 'gpt-4o-mini' }),      // $0.15/$0.60 per 1M tokens
+  drafter: new ChatOpenAI({ model: 'nous/hermes-flash' }),      // $0.15/$0.60 per 1M tokens
   verifier: new ChatAnthropic({ model: 'claude-sonnet-4-5' }),  // $3/$15 per 1M tokens
   qualityThreshold: 0.8, // 80% queries use drafter
 });
@@ -497,7 +557,7 @@ from langchain_anthropic import ChatAnthropic
 from cascadeflow.integrations.langchain import CascadeFlow
 
 cascade = CascadeFlow(
-    drafter=ChatOpenAI(model="gpt-4o-mini"),      # $0.15/$0.60 per 1M tokens
+    drafter=ChatOpenAI(model="nous/hermes-flash"),      # $0.15/$0.60 per 1M tokens
     verifier=ChatAnthropic(model="claude-sonnet-4-5"),  # $3/$15 per 1M tokens
     quality_threshold=0.8,  # 80% queries use drafter
 )
@@ -560,7 +620,7 @@ import {
 // Your existing LangChain models (configured with YOUR API keys)
 const myModels = [
   new ChatOpenAI({ model: 'gpt-3.5-turbo' }),
-  new ChatOpenAI({ model: 'gpt-4o-mini' }),
+  new ChatOpenAI({ model: 'nous/hermes-flash' }),
   new ChatOpenAI({ model: 'gpt-4o' }),
   new ChatAnthropic({ model: 'claude-3-haiku' }),
   // ... any LangChain chat models
@@ -650,7 +710,7 @@ console.log(`Warnings: ${validation.warnings}`);
 </details>
 
 <details>
-<summary><b>Framework Integrations</b> - Harness with LangChain, OpenAI Agents, CrewAI, PydanticAI, Google ADK</summary>
+<summary><b>Framework Integrations</b> - Harness with LangChain, OpenAI Agents, CrewAI, PydanticAI, Google ADK, Hermes Agent</summary>
 
 | Example | Description | Link |
 |---------|-------------|------|
@@ -759,6 +819,7 @@ console.log(`Warnings: ${validation.warnings}`);
 | **CrewAI Integration** | Use cascadeflow with CrewAI | [Read](https://docs.cascadeflow.ai/integrations/crewai) |
 | **PydanticAI Integration** | Cascade Model for PydanticAI agents | [Read](https://docs.cascadeflow.ai/integrations/pydantic-ai) |
 | **Google ADK** | Use cascadeflow with Google ADK | [Read](https://docs.cascadeflow.ai/integrations/google-adk) |
+| **Hermes Agent** | Per-skill, complexity, and topic-aware subagent routing | [Read](https://docs.cascadeflow.ai/integrations/hermes-agent) |
 | **n8n Integration** | Use cascadeflow in n8n workflows | [Read](https://docs.cascadeflow.ai/integrations/n8n) |
 | **Vercel AI SDK** | Middleware for Vercel AI SDK | [Read](https://docs.cascadeflow.ai/integrations/vercel-ai) |
 
@@ -786,6 +847,7 @@ console.log(`Warnings: ${validation.warnings}`);
 | 📊 **Cost Tracking**  | Built-in analytics + OpenTelemetry export (vendor-neutral)                                                                             |
 | 🚀 **3-Line Integration** | Zero architecture changes needed                                                                                                       |
 | 🔁 **Agent Loops** | Multi-turn tool execution with automatic tool call, result, re-prompt cycles |
+| 🧭 **Hermes Agent Routing** | Per-skill, task-complexity, and topic-aware subagent routing with observe-mode rollout |
 | 📋 **Message & Tool Call Lists** | Full conversation history with tool_calls and tool_call_id preservation across turns |
 | 🪝 **Hooks & Callbacks** | Telemetry callbacks, cost events, and streaming hooks for observability |
 | 🏭 **Production Ready**  | Streaming, batch processing, tool handling, reasoning model support, caching, error recovery, anomaly detection |

--- a/cascadeflow/__init__.py
+++ b/cascadeflow/__init__.py
@@ -17,10 +17,10 @@ Key APIs:
     session.summary()             -- structured metrics
     session.trace()               -- full decision audit trail
 
-Integrations: LangChain, OpenAI Agents SDK, CrewAI, Google ADK, n8n, Vercel AI SDK
+Integrations: LangChain, OpenAI Agents SDK, CrewAI, Google ADK, n8n, Vercel AI SDK, Hermes Agent
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __author__ = "Lemony Inc."
 __license__ = "MIT"
 

--- a/cascadeflow/integrations/__init__.py
+++ b/cascadeflow/integrations/__init__.py
@@ -11,6 +11,7 @@ Provides optional integrations with:
     - CrewAI: Harness integration for CrewAI workflows
     - Google ADK: Plugin for Google Agent Development Kit
     - PydanticAI: Full cascade Model for PydanticAI agents
+    - Hermes Agent: Delegation router for per-skill subagent routing
 
 All integrations are optional and raise ``ImportError`` with an install
 hint when the required dependency is missing.
@@ -302,6 +303,37 @@ except ImportError:
     pydantic_ai_create_cascade_model = _pydantic_ai_missing
     is_pydantic_ai_available = _pydantic_ai_missing
 
+# ═══════════════════════════════════════════════════
+# Hermes Agent
+# ═══════════════════════════════════════════════════
+
+try:
+    from .hermes import (
+        HermesDelegationDecision,
+        HermesDelegationRequest,
+        HermesDelegationRouter,
+        HermesRouteProfile,
+        HermesRoutingConfig,
+        HermesTaskClassification,
+        HermesTaskClassifier,
+        extract_cascadeflow_skill_metadata,
+        profile_from_skill_metadata,
+    )
+
+    HERMES_AVAILABLE = True
+except ImportError:
+    HERMES_AVAILABLE = False
+    _hermes_missing = _MissingIntegration("Hermes Agent", "pip install cascadeflow")
+    HermesDelegationDecision = _hermes_missing
+    HermesDelegationRequest = _hermes_missing
+    HermesDelegationRouter = _hermes_missing
+    HermesRouteProfile = _hermes_missing
+    HermesRoutingConfig = _hermes_missing
+    HermesTaskClassification = _hermes_missing
+    HermesTaskClassifier = _hermes_missing
+    extract_cascadeflow_skill_metadata = _hermes_missing
+    profile_from_skill_metadata = _hermes_missing
+
 
 # ═══════════════════════════════════════════════════
 # Exports & Capabilities
@@ -435,6 +467,22 @@ if PYDANTIC_AI_AVAILABLE:
         ]
     )
 
+if HERMES_AVAILABLE:
+    __all__.extend(
+        [
+            "HERMES_AVAILABLE",
+            "HermesDelegationDecision",
+            "HermesDelegationRequest",
+            "HermesDelegationRouter",
+            "HermesRouteProfile",
+            "HermesRoutingConfig",
+            "HermesTaskClassification",
+            "HermesTaskClassifier",
+            "extract_cascadeflow_skill_metadata",
+            "profile_from_skill_metadata",
+        ]
+    )
+
 # Integration capabilities
 INTEGRATION_CAPABILITIES = {
     "litellm": LITELLM_AVAILABLE,
@@ -446,6 +494,7 @@ INTEGRATION_CAPABILITIES = {
     "crewai": CREWAI_AVAILABLE,
     "google_adk": GOOGLE_ADK_AVAILABLE,
     "pydantic_ai": PYDANTIC_AI_AVAILABLE,
+    "hermes": HERMES_AVAILABLE,
 }
 
 
@@ -473,4 +522,5 @@ def get_integration_info():
         "crewai_available": CREWAI_AVAILABLE,
         "google_adk_available": GOOGLE_ADK_AVAILABLE,
         "pydantic_ai_available": PYDANTIC_AI_AVAILABLE,
+        "hermes_available": HERMES_AVAILABLE,
     }

--- a/cascadeflow/integrations/hermes/README.md
+++ b/cascadeflow/integrations/hermes/README.md
@@ -1,0 +1,39 @@
+# CascadeFlow Hermes Agent Integration
+
+Optional delegation router for Hermes Agent subagents.
+
+Hermes owns provider credentials, base URLs, fallback chains, and API modes.
+CascadeFlow returns an auditable recommendation before Hermes spawns a child
+agent.
+
+```python
+from cascadeflow.integrations.hermes import (
+    HermesDelegationRequest,
+    HermesDelegationRouter,
+)
+
+router = HermesDelegationRouter.from_dict({
+    "enabled": True,
+    "mode": "observe",
+    "routes": {
+        "simple": {"provider": "openai", "model": "gpt-4.1-mini", "reasoning_effort": "low"},
+        "code": {"provider": "nous", "model": "nous/hermes-4.1", "reasoning_effort": "high"},
+    },
+})
+
+decision = router.route_delegation(HermesDelegationRequest(
+    goal="Debug the failing unit test and propose a patch",
+    toolsets=("terminal", "git"),
+    loaded_skills=("python", "debugging"),
+))
+```
+
+The integration supports:
+
+- per-skill model and reasoning profiles through skill metadata
+- task-complexity routing for simple versus hard delegated tasks
+- topic-aware routing for code, research, data, creative, ops, legal, medical, and finance work
+- observe mode for dry-run rollout
+- structured decision audit fields
+- inherit fallbacks for disabled config, low confidence, errors, and unconfigured high-stakes domains
+

--- a/cascadeflow/integrations/hermes/__init__.py
+++ b/cascadeflow/integrations/hermes/__init__.py
@@ -1,0 +1,29 @@
+"""Hermes Agent integration for CascadeFlow.
+
+This package provides a dependency-free router that Hermes can call before
+spawning ``delegate_task`` child agents. CascadeFlow recommends provider,
+model, and reasoning-effort targets; Hermes remains responsible for
+credentials, base URLs, fallback chains, and child-agent construction.
+"""
+
+from .classifier import HermesTaskClassification, HermesTaskClassifier
+from .config import HermesRouteProfile, HermesRoutingConfig
+from .router import HermesDelegationRouter
+from .skill_metadata import (
+    extract_cascadeflow_skill_metadata,
+    profile_from_skill_metadata,
+)
+from .types import HermesDelegationDecision, HermesDelegationRequest
+
+__all__ = [
+    "HermesDelegationDecision",
+    "HermesDelegationRequest",
+    "HermesDelegationRouter",
+    "HermesRouteProfile",
+    "HermesRoutingConfig",
+    "HermesTaskClassification",
+    "HermesTaskClassifier",
+    "extract_cascadeflow_skill_metadata",
+    "profile_from_skill_metadata",
+]
+

--- a/cascadeflow/integrations/hermes/classifier.py
+++ b/cascadeflow/integrations/hermes/classifier.py
@@ -1,0 +1,154 @@
+"""Deterministic task classifier for Hermes Agent delegation routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from cascadeflow.quality.complexity import ComplexityDetector, QueryComplexity
+
+from .types import HermesDelegationRequest
+
+DOMAIN_KEYWORDS = {
+    "debugging": {
+        "traceback",
+        "stack trace",
+        "failing test",
+        "regression",
+        "root cause",
+        "bug",
+        "debug",
+    },
+    "code": {
+        "code",
+        "implement",
+        "refactor",
+        "typescript",
+        "python",
+        "api",
+        "schema",
+        "database",
+        "pull request",
+        "unit test",
+    },
+    "research": {
+        "research",
+        "investigate",
+        "summarize",
+        "compare",
+        "source",
+        "citations",
+        "web",
+        "market",
+    },
+    "data": {
+        "dataset",
+        "sql",
+        "analytics",
+        "csv",
+        "postgres",
+        "warehouse",
+        "metrics",
+        "dashboard",
+    },
+    "creative": {
+        "copy",
+        "creative",
+        "design",
+        "story",
+        "brand",
+        "headline",
+        "script",
+        "visual",
+    },
+    "ops": {
+        "deploy",
+        "docker",
+        "kubernetes",
+        "ci",
+        "workflow",
+        "infrastructure",
+        "logs",
+        "incident",
+    },
+    "legal": {"legal", "contract", "law", "compliance", "terms", "privacy"},
+    "medical": {"medical", "health", "diagnosis", "treatment", "patient", "clinical"},
+    "finance": {"finance", "financial", "investment", "tax", "invoice", "revenue"},
+}
+
+HIGH_STAKES_DOMAINS = {"legal", "medical", "finance"}
+TOOLSET_DOMAIN_HINTS = {
+    "terminal": "code",
+    "file": "code",
+    "git": "code",
+    "browser": "research",
+    "web": "research",
+}
+
+
+@dataclass(frozen=True)
+class HermesTaskClassification:
+    domain: str
+    complexity: str
+    confidence: float
+    reason: str
+    topic: Optional[str] = None
+
+
+class HermesTaskClassifier:
+    """Classify Hermes delegated tasks by domain and complexity."""
+
+    def __init__(self, complexity_detector: Optional[ComplexityDetector] = None):
+        self.complexity_detector = complexity_detector or ComplexityDetector()
+
+    def classify(self, request: HermesDelegationRequest) -> HermesTaskClassification:
+        text = request.text_for_classification()
+        lowered = text.lower()
+        domain, domain_confidence, domain_reason = self._detect_domain(
+            lowered,
+            request.toolsets,
+        )
+        complexity, complexity_confidence = self._detect_complexity(text)
+        confidence = max(domain_confidence, complexity_confidence * 0.75)
+        if domain == "general" and complexity in {"trivial", "simple"}:
+            domain = "simple"
+            domain_reason = "simple_complexity"
+            confidence = max(confidence, 0.72)
+        return HermesTaskClassification(
+            domain=domain,
+            topic=domain if domain != "simple" else None,
+            complexity=complexity,
+            confidence=max(0.0, min(1.0, confidence)),
+            reason=domain_reason,
+        )
+
+    def _detect_domain(self, lowered: str, toolsets: tuple[str, ...]) -> tuple[str, float, str]:
+        scores: dict[str, int] = {}
+        for domain, keywords in DOMAIN_KEYWORDS.items():
+            hits = sum(1 for keyword in keywords if keyword in lowered)
+            if hits:
+                scores[domain] = hits
+
+        for toolset in toolsets:
+            hinted = TOOLSET_DOMAIN_HINTS.get(toolset)
+            if hinted:
+                scores[hinted] = scores.get(hinted, 0) + 1
+
+        if not scores:
+            return "general", 0.35, "no_domain_markers"
+
+        domain = max(scores, key=scores.get)
+        confidence = min(0.95, 0.55 + (scores[domain] * 0.12))
+        return domain, confidence, "keyword_and_toolset_match"
+
+    def _detect_complexity(self, text: str) -> tuple[str, float]:
+        try:
+            complexity, confidence = self.complexity_detector.detect(text)
+        except Exception:
+            return "moderate", 0.4
+        if isinstance(complexity, QueryComplexity):
+            complexity_value = complexity.value
+        else:
+            complexity_value = str(complexity)
+        return complexity_value, max(0.0, min(1.0, float(confidence or 0.0)))
+

--- a/cascadeflow/integrations/hermes/config.py
+++ b/cascadeflow/integrations/hermes/config.py
@@ -1,0 +1,105 @@
+"""Configuration helpers for Hermes Agent delegation routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
+
+from .types import VALID_REASONING_EFFORTS
+
+VALID_MODES = {"observe", "route"}
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _clean_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+@dataclass(frozen=True)
+class HermesRouteProfile:
+    """Provider/model/reasoning target for a domain, topic, skill, or complexity."""
+
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    domain: Optional[str] = None
+    topic: Optional[str] = None
+    confidence: float = 0.8
+    description: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> HermesRouteProfile:
+        effort = _clean_str(data.get("reasoning_effort"))
+        if effort is not None:
+            effort = effort.lower()
+        if effort is not None and effort not in VALID_REASONING_EFFORTS:
+            effort = None
+        try:
+            confidence = float(data.get("confidence", 0.8))
+        except (TypeError, ValueError):
+            confidence = 0.8
+        return cls(
+            provider=_clean_str(data.get("provider")),
+            model=_clean_str(data.get("model")),
+            reasoning_effort=effort,
+            domain=_clean_str(data.get("domain")),
+            topic=_clean_str(data.get("topic")),
+            confidence=max(0.0, min(1.0, confidence)),
+            description=_clean_str(data.get("description")),
+        )
+
+
+@dataclass(frozen=True)
+class HermesRoutingConfig:
+    """Configuration for CascadeFlow's Hermes delegation router."""
+
+    enabled: bool = False
+    mode: str = "observe"
+    min_confidence: float = 0.60
+    route_reasoning_effort: bool = True
+    route_provider_model: bool = True
+    log_decisions: bool = True
+    routes: Mapping[str, HermesRouteProfile] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Optional[Mapping[str, Any]]) -> HermesRoutingConfig:
+        if not isinstance(data, Mapping):
+            return cls()
+        mode = str(data.get("mode", "observe") or "observe").strip().lower()
+        if mode not in VALID_MODES:
+            mode = "observe"
+        try:
+            min_confidence = float(data.get("min_confidence", 0.60))
+        except (TypeError, ValueError):
+            min_confidence = 0.60
+        raw_routes = data.get("routes") or {}
+        routes: dict[str, HermesRouteProfile] = {}
+        if isinstance(raw_routes, Mapping):
+            for key, value in raw_routes.items():
+                route_key = str(key).strip().lower()
+                if route_key and isinstance(value, Mapping):
+                    routes[route_key] = HermesRouteProfile.from_dict(value)
+        return cls(
+            enabled=_as_bool(data.get("enabled"), default=False),
+            mode=mode,
+            min_confidence=max(0.0, min(1.0, min_confidence)),
+            route_reasoning_effort=_as_bool(
+                data.get("route_reasoning_effort"),
+                default=True,
+            ),
+            route_provider_model=_as_bool(data.get("route_provider_model"), default=True),
+            log_decisions=_as_bool(data.get("log_decisions"), default=True),
+            routes=routes,
+        )

--- a/cascadeflow/integrations/hermes/router.py
+++ b/cascadeflow/integrations/hermes/router.py
@@ -1,0 +1,162 @@
+"""Hermes Agent delegation router."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .classifier import HIGH_STAKES_DOMAINS, HermesTaskClassifier
+from .config import HermesRouteProfile, HermesRoutingConfig
+from .skill_metadata import profile_from_skill_metadata
+from .types import HermesDelegationDecision, HermesDelegationRequest
+
+
+class HermesDelegationRouter:
+    """Return routing recommendations for Hermes ``delegate_task`` children."""
+
+    def __init__(
+        self,
+        config: Optional[HermesRoutingConfig] = None,
+        classifier: Optional[HermesTaskClassifier] = None,
+    ):
+        self.config = config or HermesRoutingConfig()
+        self.classifier = classifier or HermesTaskClassifier()
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict]) -> HermesDelegationRouter:
+        return cls(config=HermesRoutingConfig.from_dict(data))
+
+    def route_delegation(
+        self,
+        request: HermesDelegationRequest,
+    ) -> HermesDelegationDecision:
+        try:
+            return self._route_delegation(request)
+        except Exception as exc:
+            return HermesDelegationDecision(
+                action="inherit",
+                confidence=0.0,
+                reason="router_error",
+                source="fallback",
+                metadata={"error": exc.__class__.__name__},
+            )
+
+    def _route_delegation(
+        self,
+        request: HermesDelegationRequest,
+    ) -> HermesDelegationDecision:
+        if not self.config.enabled:
+            return HermesDelegationDecision(
+                action="inherit",
+                confidence=0.0,
+                reason="cascadeflow_disabled",
+                source="config",
+            )
+
+        skill_profile = profile_from_skill_metadata(request.skill_metadata)
+        if skill_profile is not None:
+            return self._decision_from_profile(
+                skill_profile,
+                request=request,
+                source="skill_metadata",
+                reason="explicit_skill_metadata",
+                domain=skill_profile.domain,
+                topic=skill_profile.topic,
+                complexity=None,
+                confidence=skill_profile.confidence or 1.0,
+            )
+
+        classification = self.classifier.classify(request)
+        route_key = self._select_route_key(classification.domain, classification.complexity)
+        profile = self.config.routes.get(route_key) if route_key else None
+        if profile is None and classification.domain in HIGH_STAKES_DOMAINS:
+            return HermesDelegationDecision(
+                action="inherit",
+                domain=classification.domain,
+                topic=classification.topic,
+                complexity=classification.complexity,
+                confidence=classification.confidence,
+                reason="high_stakes_domain_unconfigured",
+                source="classifier",
+                metadata={"route_key": route_key},
+            )
+        if profile is None:
+            return HermesDelegationDecision(
+                action="inherit",
+                domain=classification.domain,
+                topic=classification.topic,
+                complexity=classification.complexity,
+                confidence=classification.confidence,
+                reason="no_matching_route",
+                source="classifier",
+                metadata={"route_key": route_key},
+            )
+
+        return self._decision_from_profile(
+            profile,
+            request=request,
+            source="classifier",
+            reason=classification.reason,
+            domain=profile.domain or classification.domain,
+            topic=profile.topic or classification.topic,
+            complexity=classification.complexity,
+            confidence=min(1.0, max(classification.confidence, profile.confidence)),
+        )
+
+    def _select_route_key(self, domain: str, complexity: str) -> str:
+        normalized_domain = (domain or "").lower()
+        normalized_complexity = (complexity or "").lower()
+        if normalized_domain in self.config.routes:
+            return normalized_domain
+        if normalized_domain == "debugging" and "code" in self.config.routes:
+            return "code"
+        if normalized_complexity in self.config.routes:
+            return normalized_complexity
+        if normalized_complexity in {"trivial", "simple"} and "simple" in self.config.routes:
+            return "simple"
+        if normalized_complexity in {"hard", "expert"} and "hard" in self.config.routes:
+            return "hard"
+        if "general" in self.config.routes:
+            return "general"
+        return normalized_domain or normalized_complexity
+
+    def _decision_from_profile(
+        self,
+        profile: HermesRouteProfile,
+        *,
+        request: HermesDelegationRequest,
+        source: str,
+        reason: str,
+        domain: Optional[str],
+        topic: Optional[str],
+        complexity: Optional[str],
+        confidence: float,
+    ) -> HermesDelegationDecision:
+        confidence = max(0.0, min(1.0, confidence))
+        below_threshold = confidence < self.config.min_confidence
+        action = "route"
+        if self.config.mode == "observe" or below_threshold:
+            action = "inherit"
+
+        provider = profile.provider if self.config.route_provider_model else None
+        model = profile.model if self.config.route_provider_model else None
+        reasoning_effort = (
+            profile.reasoning_effort if self.config.route_reasoning_effort else None
+        )
+        return HermesDelegationDecision(
+            action=action,
+            provider=provider,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            domain=domain,
+            topic=topic,
+            complexity=complexity,
+            confidence=confidence,
+            reason="confidence_below_threshold" if below_threshold else reason,
+            source=source,
+            metadata={
+                "mode": self.config.mode,
+                "would_route": bool(provider or model or reasoning_effort),
+                "applied": action == "route",
+                "loaded_skills": list(request.loaded_skills),
+            },
+        )

--- a/cascadeflow/integrations/hermes/skill_metadata.py
+++ b/cascadeflow/integrations/hermes/skill_metadata.py
@@ -1,0 +1,45 @@
+"""Skill metadata helpers for Hermes Agent routing."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from .config import HermesRouteProfile
+
+
+def extract_cascadeflow_skill_metadata(metadata: Optional[Mapping[str, Any]]) -> dict[str, Any]:
+    """Extract a normalized ``cascadeflow`` routing block from skill metadata.
+
+    Hermes skill metadata may eventually arrive as frontmatter, a nested
+    ``metadata.hermes.cascadeflow`` block, or a direct ``cascadeflow`` dict.
+    This helper accepts already-parsed dictionaries and never reads Hermes
+    skill files directly.
+    """
+
+    if not isinstance(metadata, Mapping):
+        return {}
+
+    direct = metadata.get("cascadeflow")
+    if isinstance(direct, Mapping):
+        return dict(direct)
+
+    nested = metadata.get("metadata")
+    if isinstance(nested, Mapping):
+        hermes = nested.get("hermes")
+        if isinstance(hermes, Mapping):
+            cascadeflow = hermes.get("cascadeflow")
+            if isinstance(cascadeflow, Mapping):
+                return dict(cascadeflow)
+
+    return {}
+
+
+def profile_from_skill_metadata(
+    metadata: Optional[Mapping[str, Any]],
+) -> Optional[HermesRouteProfile]:
+    """Return a route profile from explicit skill metadata, if present."""
+
+    block = extract_cascadeflow_skill_metadata(metadata)
+    if not block:
+        return None
+    return HermesRouteProfile.from_dict(block)

--- a/cascadeflow/integrations/hermes/types.py
+++ b/cascadeflow/integrations/hermes/types.py
@@ -1,0 +1,154 @@
+"""Types for the Hermes Agent delegation-routing integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
+
+VALID_ACTIONS = {"inherit", "route"}
+VALID_REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
+
+
+def _clean_text(value: Any, *, max_length: int = 500) -> str:
+    if value is None:
+        return ""
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    text = "".join(ch for ch in text if ch.isprintable())
+    if len(text) > max_length:
+        text = text[: max_length - 3] + "..."
+    return text
+
+
+def _clean_optional(value: Any, *, max_length: int = 160) -> Optional[str]:
+    text = _clean_text(value, max_length=max_length)
+    return text or None
+
+
+def _clean_tuple(values: Any) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    if isinstance(values, str):
+        values = (values,)
+    try:
+        return tuple(
+            item
+            for item in (_clean_text(v, max_length=120) for v in values)
+            if item
+        )
+    except TypeError:
+        return ()
+
+
+@dataclass(frozen=True)
+class HermesDelegationRequest:
+    """Normalized task data Hermes passes before spawning a child agent."""
+
+    goal: str
+    context: Optional[str] = None
+    toolsets: tuple[str, ...] = ()
+    role: str = "leaf"
+    parent_provider: Optional[str] = None
+    parent_model: Optional[str] = None
+    loaded_skills: tuple[str, ...] = ()
+    skill_metadata: Optional[Mapping[str, Any]] = None
+    task_metadata: Optional[Mapping[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "goal", _clean_text(self.goal, max_length=2000))
+        object.__setattr__(
+            self,
+            "context",
+            _clean_optional(self.context, max_length=4000),
+        )
+        object.__setattr__(self, "toolsets", _clean_tuple(self.toolsets))
+        object.__setattr__(self, "role", _clean_text(self.role or "leaf", max_length=32))
+        object.__setattr__(
+            self,
+            "parent_provider",
+            _clean_optional(self.parent_provider, max_length=80),
+        )
+        object.__setattr__(
+            self,
+            "parent_model",
+            _clean_optional(self.parent_model, max_length=160),
+        )
+        object.__setattr__(self, "loaded_skills", _clean_tuple(self.loaded_skills))
+
+    def text_for_classification(self) -> str:
+        parts = [self.goal]
+        if self.context:
+            parts.append(self.context)
+        if self.loaded_skills:
+            parts.append(" ".join(self.loaded_skills))
+        return "\n".join(part for part in parts if part)
+
+
+@dataclass(frozen=True)
+class HermesDelegationDecision:
+    """Routing recommendation returned to Hermes.
+
+    ``action="route"`` means Hermes may apply provider/model/reasoning fields
+    after validating them with its own provider and credential system.
+    ``action="inherit"`` means Hermes should keep existing behavior. In observe
+    mode the decision may still include recommended fields for logging.
+    """
+
+    action: str = "inherit"
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    domain: Optional[str] = None
+    topic: Optional[str] = None
+    complexity: Optional[str] = None
+    confidence: float = 0.0
+    reason: str = "default"
+    source: str = "default"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        action = _clean_text(self.action or "inherit", max_length=24).lower()
+        if action not in VALID_ACTIONS:
+            action = "inherit"
+        object.__setattr__(self, "action", action)
+        object.__setattr__(
+            self,
+            "provider",
+            _clean_optional(self.provider, max_length=80),
+        )
+        object.__setattr__(self, "model", _clean_optional(self.model, max_length=160))
+        effort = _clean_optional(self.reasoning_effort, max_length=32)
+        if effort is not None:
+            effort = effort.lower()
+        if effort is not None and effort not in VALID_REASONING_EFFORTS:
+            effort = None
+        object.__setattr__(self, "reasoning_effort", effort)
+        object.__setattr__(self, "domain", _clean_optional(self.domain, max_length=80))
+        object.__setattr__(self, "topic", _clean_optional(self.topic, max_length=80))
+        object.__setattr__(
+            self,
+            "complexity",
+            _clean_optional(self.complexity, max_length=40),
+        )
+        object.__setattr__(self, "reason", _clean_text(self.reason, max_length=240))
+        object.__setattr__(self, "source", _clean_text(self.source, max_length=80))
+        confidence = max(0.0, min(1.0, float(self.confidence or 0.0)))
+        object.__setattr__(self, "confidence", confidence)
+
+    @property
+    def applies(self) -> bool:
+        return self.action == "route"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "provider": self.provider,
+            "model": self.model,
+            "reasoning_effort": self.reasoning_effort,
+            "domain": self.domain,
+            "topic": self.topic,
+            "complexity": self.complexity,
+            "confidence": self.confidence,
+            "reason": self.reason,
+            "source": self.source,
+            "metadata": dict(self.metadata or {}),
+        }

--- a/docs-site/capabilities/overview.mdx
+++ b/docs-site/capabilities/overview.mdx
@@ -29,6 +29,7 @@ The complete capability map for cascadeflow. Every feature links to its deep-div
 | Google ADK | [/integrations/google-adk](/integrations/google-adk) | [examples/integrations/google_adk_harness.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/integrations/google_adk_harness.py) |
 | Vercel AI SDK | [/integrations/vercel-ai](/integrations/vercel-ai) | [examples/vercel-ai-nextjs](https://github.com/lemony-ai/cascadeflow/tree/main/examples/vercel-ai-nextjs) |
 | n8n | [/integrations/n8n](/integrations/n8n) | [packages/integrations/n8n](https://github.com/lemony-ai/cascadeflow/tree/main/packages/integrations/n8n) |
+| Hermes Agent | [/integrations/hermes-agent](/integrations/hermes-agent) | `cascadeflow.integrations.hermes` |
 
 ## Use This Page As The Hub
 
@@ -37,7 +38,7 @@ The complete capability map for cascadeflow. Every feature links to its deep-div
     Install and start observing in minutes.
   </Card>
   <Card title="Integrations" icon="puzzle-piece" href="/integrations/overview">
-    LangChain, OpenAI Agents, CrewAI, Google ADK, Vercel AI, n8n.
+    LangChain, OpenAI Agents, CrewAI, Google ADK, Vercel AI, n8n, Hermes Agent.
   </Card>
   <Card title="For Coding Agents" icon="robot" href="/for-coding-agents">
     Canonical repo map and implementation entry points.

--- a/docs-site/changelog.mdx
+++ b/docs-site/changelog.mdx
@@ -13,6 +13,7 @@ For the full release history, see [GitHub Releases](https://github.com/lemony-ai
 - Hooks and callbacks for telemetry and observability
 - Vercel AI SDK integration (17+ additional providers)
 - OpenClaw provider for custom deployments
+- Hermes Agent delegation router for per-skill, task-complexity, and topic-aware subagent routing
 - Gateway server (drop-in OpenAI/Anthropic-compatible endpoint)
 - User tier management with per-user budgets
 - Semantic quality validators via FastEmbed

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -87,7 +87,8 @@
               "integrations/pydantic-ai",
               "integrations/vercel-ai",
               "integrations/n8n",
-              "integrations/openclaw"
+              "integrations/openclaw",
+              "integrations/hermes-agent"
             ]
           },
           {

--- a/docs-site/for-coding-agents.mdx
+++ b/docs-site/for-coding-agents.mdx
@@ -123,7 +123,7 @@ cascadeflow/
 │   ├── tools/             # Tool calling framework
 │   ├── streaming/         # Response streaming
 │   ├── telemetry/         # Cost tracking, metrics, callbacks
-│   ├── integrations/      # Framework bridges (LangChain, OpenClaw)
+│   ├── integrations/      # Framework bridges (LangChain, OpenClaw, Hermes Agent)
 │   ├── limits/            # Budget enforcement
 │   ├── guardrails/        # Safety guardrails
 │   ├── providers/         # LLM providers (OpenAI, Anthropic, Groq, Ollama, vLLM)

--- a/docs-site/get-started/choose-integration.mdx
+++ b/docs-site/get-started/choose-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Choose Your Integration
-description: Pick the right cascadeflow integration for your framework — LangChain, OpenAI Agents, CrewAI, Google ADK, n8n, or Vercel AI.
+description: Pick the right cascadeflow integration for your framework — LangChain, OpenAI Agents, CrewAI, Google ADK, n8n, Vercel AI, or Hermes Agent.
 ---
 
 # Choose Your Integration
@@ -17,6 +17,7 @@ cascadeflow integrates with every major agent framework. Pick the one that match
 | **Google ADK** | `pip install cascadeflow[google-adk]` | BasePlugin | [Google ADK →](/integrations/google-adk) |
 | **Vercel AI SDK** | `npm install @cascadeflow/vercel-ai` | Middleware | [Vercel AI →](/integrations/vercel-ai) |
 | **n8n** | `npm install @cascadeflow/n8n-nodes-cascadeflow` | Community node | [n8n →](/integrations/n8n) |
+| **Hermes Agent** | `pip install cascadeflow` | Delegation router | [Hermes Agent →](/integrations/hermes-agent) |
 | **Direct SDK calls** | `pip install cascadeflow` | `init()` + `run()` | [Observe →](/get-started/observe) |
 | **TypeScript (no framework)** | `npm install @cascadeflow/core` | CascadeAgent | [Core →](/api-reference/typescript/core) |
 
@@ -43,6 +44,10 @@ hooks = CascadeFlowHooks()
 # Google ADK — plugin
 from cascadeflow.integrations.google_adk import CascadeFlowPlugin
 plugin = CascadeFlowPlugin()
+
+# Hermes Agent — delegation router
+from cascadeflow.integrations.hermes import HermesDelegationRouter
+router = HermesDelegationRouter.from_dict({"enabled": True, "mode": "observe"})
 ```
 
 ### TypeScript
@@ -72,6 +77,9 @@ import { withCascade } from '@cascadeflow/langchain';
   </Card>
   <Card title="No-code / Low-code" icon="wand-magic-sparkles" href="/integrations/n8n">
     n8n community nodes for visual workflow automation.
+  </Card>
+  <Card title="Hermes subagents" icon="route" href="/integrations/hermes-agent">
+    Per-skill, complexity-aware, and topic-aware routing for delegated agents.
   </Card>
 </CardGroup>
 

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -106,6 +106,7 @@ Every agent step is scored across six dimensions simultaneously:
 | Google ADK | `cascadeflow[google-adk]` | — | BasePlugin |
 | n8n | — | `@cascadeflow/n8n-nodes-cascadeflow` | Community node |
 | Vercel AI SDK | — | `@cascadeflow/vercel-ai` | Middleware |
+| Hermes Agent | `cascadeflow` | — | Delegation router |
 
 ## Explore
 
@@ -120,7 +121,7 @@ Every agent step is scored across six dimensions simultaneously:
     42+ Python and 33+ TypeScript examples on GitHub.
   </Card>
   <Card title="Integrations" icon="puzzle-piece" href="/integrations/overview">
-    LangChain, OpenAI Agents, CrewAI, Google ADK, n8n, Vercel AI.
+    LangChain, OpenAI Agents, CrewAI, Google ADK, n8n, Vercel AI, Hermes Agent.
   </Card>
   <Card title="API Reference" icon="book" href="/api-reference/python/init">
     Full Python and TypeScript API documentation.

--- a/docs-site/integrations/hermes-agent.mdx
+++ b/docs-site/integrations/hermes-agent.mdx
@@ -1,0 +1,237 @@
+---
+title: Hermes Agent
+description: Optional CascadeFlow delegation router for Hermes Agent with per-skill, task-complexity, and topic-aware subagent routing.
+---
+
+CascadeFlow can be used as a native Hermes Agent delegation router. Hermes keeps ownership of provider credentials, base URLs, fallback chains, and API modes. CascadeFlow returns a structured decision before Hermes creates a delegated subagent.
+
+The integration is intentionally optional: start in `observe`, log what CascadeFlow would do, then switch to `route` once the routing policy is trusted.
+
+You do not need to wait for a Hermes upstream PR to test the value. The router is a standalone CascadeFlow module that can run from a local wrapper, local Hermes fork, or hook script. Native Hermes support only makes the UX cleaner.
+
+## What It Solves
+
+Hermes Agent users often need finer control than one inherited model default for every delegated subagent. This integration targets three routing gaps:
+
+- **Per-skill model routing:** a coding skill, research skill, legal/finance skill, or lightweight utility skill can receive a different model and reasoning profile instead of inheriting one global default.
+- **Task-complexity routing:** simple delegated tasks can use cheaper/faster models, while hard debugging, architecture, research, or code-generation tasks can route to stronger models.
+- **Topic-aware subagent routing:** subagents can route differently for code, research, data, creative, ops, medical, legal, finance, and other domains.
+
+## Why Use It
+
+- **Better subagent economics:** avoid paying flagship-model prices for simple worker tasks.
+- **Better quality for hard tasks:** avoid sending difficult subagent work to weak or cheap default models.
+- **Dry-run/observe mode:** see what CascadeFlow would route without changing runtime behavior.
+- **Auditability:** routing decisions carry `reason`, `confidence`, `domain`, `complexity`, and selected model fields.
+- **Safer rollout:** missing CascadeFlow, disabled config, low confidence, high-stakes gaps, bad config, or router errors fall back to Hermes' current behavior.
+- **No credential rewrite:** Hermes still owns provider credentials, base URLs, fallback chains, and API modes.
+
+## Install
+
+```bash
+pip install cascadeflow
+```
+
+No extra Hermes-specific package is required.
+
+## Use Without A Hermes PR
+
+If Hermes has not accepted native support yet, users can still release and use this integration from CascadeFlow:
+
+1. Install `cascadeflow` in the same Python environment as the local Hermes wrapper or fork.
+2. Call `HermesDelegationRouter.route_delegation()` before spawning a delegated subagent.
+3. Log decisions in `observe` mode first.
+4. In `route` mode, apply only fields Hermes validates against its own provider configuration.
+
+The released module still provides the core advantages:
+
+- per-skill routing through parsed skill metadata
+- task-complexity routing for simple versus hard delegated work
+- topic-aware routing for code, research, data, creative, ops, medical, legal, and finance
+- cheaper/faster models for simple worker tasks
+- stronger models for hard debugging, architecture, research, and code-generation tasks
+- dry-run decisions, audit fields, and safe fallbacks
+- no rewrite of Hermes credentials, base URLs, fallback chains, or API modes
+
+Standalone example:
+
+```bash
+PYTHONPATH=. python examples/integrations/hermes_delegation_router.py
+```
+
+## Basic Router
+
+```python
+from cascadeflow.integrations.hermes import (
+    HermesDelegationRequest,
+    HermesDelegationRouter,
+)
+
+router = HermesDelegationRouter.from_dict({
+    "enabled": True,
+    "mode": "observe",
+    "min_confidence": 0.6,
+    "routes": {
+        "simple": {
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "reasoning_effort": "low",
+        },
+        "code": {
+            "provider": "nous",
+            "model": "nous/hermes-4.1",
+            "reasoning_effort": "high",
+        },
+        "research": {
+            "provider": "nous",
+            "model": "nous/hermes-research",
+            "reasoning_effort": "medium",
+        },
+    },
+})
+
+decision = router.route_delegation(HermesDelegationRequest(
+    goal="Debug the failing pytest regression and propose a patch",
+    context="The parent agent is working on a Python API client.",
+    toolsets=("terminal", "git"),
+    loaded_skills=("python", "debugging"),
+    parent_provider="openai",
+    parent_model="gpt-4.1-mini",
+))
+
+print(decision.to_dict())
+```
+
+Example observe-mode output:
+
+```json
+{
+  "action": "inherit",
+  "provider": "nous",
+  "model": "nous/hermes-4.1",
+  "reasoning_effort": "high",
+  "domain": "debugging",
+  "topic": "debugging",
+  "complexity": "hard",
+  "confidence": 0.91,
+  "reason": "keyword_and_toolset_match",
+  "source": "classifier",
+  "metadata": {
+    "mode": "observe",
+    "would_route": true,
+    "applied": false,
+    "loaded_skills": ["python", "debugging"]
+  }
+}
+```
+
+In `observe`, Hermes should log the recommendation and keep existing behavior. In `route`, Hermes may apply `provider`, `model`, and `reasoning_effort` after validating them against its own configuration.
+
+## Route Mode
+
+```python
+router = HermesDelegationRouter.from_dict({
+    "enabled": True,
+    "mode": "route",
+    "min_confidence": 0.75,
+    "routes": {
+        "simple": {"provider": "openai", "model": "gpt-4.1-mini", "reasoning_effort": "low"},
+        "hard": {"provider": "anthropic", "model": "claude-opus-4.1", "reasoning_effort": "high"},
+        "code": {"provider": "nous", "model": "nous/hermes-4.1", "reasoning_effort": "high"},
+        "research": {"provider": "nous", "model": "nous/hermes-research", "reasoning_effort": "medium"},
+        "general": {"provider": "openai", "model": "gpt-4.1-mini", "reasoning_effort": "medium"},
+    },
+})
+```
+
+Route keys may be domain names such as `code`, `research`, `data`, `creative`, `ops`, `legal`, `medical`, and `finance`, or complexity names such as `simple` and `hard`.
+
+## Per-Skill Metadata
+
+Hermes can let skill frontmatter or parsed skill metadata override the classifier. A skill-specific profile is the strongest signal and is useful for specialist skills that should always receive the same model class.
+
+```yaml
+---
+name: contract-review
+description: Review legal agreements and identify risky clauses.
+cascadeflow:
+  provider: anthropic
+  model: claude-opus-4.1
+  reasoning_effort: high
+  domain: legal
+  topic: contract-review
+  confidence: 0.99
+---
+```
+
+Pass the parsed metadata into the request:
+
+```python
+decision = router.route_delegation(HermesDelegationRequest(
+    goal="Review this indemnity clause.",
+    loaded_skills=("contract-review",),
+    skill_metadata={
+        "cascadeflow": {
+            "provider": "anthropic",
+            "model": "claude-opus-4.1",
+            "reasoning_effort": "high",
+            "domain": "legal",
+            "topic": "contract-review",
+            "confidence": 0.99,
+        }
+    },
+))
+```
+
+## Fallback Behavior
+
+The router is designed to be safe to call from Hermes' delegation path:
+
+- `enabled: false` returns `action: "inherit"`
+- `mode: "observe"` returns recommendations without applying them
+- confidence below `min_confidence` returns `action: "inherit"`
+- high-stakes domains such as medical, legal, and finance inherit unless explicitly configured
+- invalid reasoning effort values are ignored
+- classifier errors return `action: "inherit"` with `reason: "router_error"`
+
+## Decision Contract
+
+Hermes should treat the result as a recommendation:
+
+```python
+if decision.action == "route":
+    # Validate provider/model against Hermes config before applying.
+    child_provider = decision.provider or parent_provider
+    child_model = decision.model or parent_model
+else:
+    child_provider = parent_provider
+    child_model = parent_model
+```
+
+Recommended fields:
+
+| Field | Meaning |
+|---|---|
+| `action` | `route` or `inherit` |
+| `provider` | Optional provider recommendation |
+| `model` | Optional model recommendation |
+| `reasoning_effort` | Optional reasoning profile such as `low`, `medium`, or `high` |
+| `domain` | Detected or configured domain |
+| `topic` | More specific topic when available |
+| `complexity` | Detected task complexity |
+| `confidence` | Routing confidence from `0.0` to `1.0` |
+| `reason` | Human-readable routing reason |
+| `source` | `skill_metadata`, `classifier`, `config`, or `fallback` |
+| `metadata` | Audit fields such as mode, would-route flag, and loaded skills |
+
+## PR Shape For Hermes
+
+The intended upstream PR should stay narrow:
+
+1. Add an optional dependency path for `cascadeflow`.
+2. Add a Hermes config block for `cascadeflow_model_routing`.
+3. Call `HermesDelegationRouter.route_delegation()` before spawning delegated subagents.
+4. Start with `mode: "observe"` so users can inspect routing decisions.
+5. Apply route decisions only after Hermes validates provider and model against its own configured providers.
+
+This keeps CascadeFlow as an integration layer, not a replacement for Hermes' provider system.

--- a/docs-site/integrations/overview.mdx
+++ b/docs-site/integrations/overview.mdx
@@ -3,7 +3,7 @@ title: Integrations Overview
 description: Matrix of all cascadeflow framework integrations with supported features, languages, and integration patterns.
 ---
 
-cascadeflow integrates with seven agent frameworks, but the product direction stays the same in every case: runtime intelligence inside the agent loop, not another proxy layer outside it.
+cascadeflow integrates with major agent frameworks and automation runtimes, but the product direction stays the same in every case: runtime intelligence inside the agent loop, not another proxy layer outside it.
 
 All integrations are opt-in. Install the extra, enable the framework extension point, start in `observe`, then move to enforcement once you understand the live runtime behavior.
 
@@ -18,6 +18,7 @@ All integrations are opt-in. Install the extra, enable the framework extension p
 | [PydanticAI](/integrations/pydantic-ai) | Python | `cascadeflow[pydantic-ai]` | Cascade Model | Yes | Yes | Yes |
 | [n8n](/integrations/n8n) | TypeScript | `@cascadeflow/n8n-nodes-cascadeflow` | Community node | Yes | Yes | Yes |
 | [Vercel AI SDK](/integrations/vercel-ai) | TypeScript | `@cascadeflow/vercel-ai` | Middleware | Yes | No | Yes |
+| [Hermes Agent](/integrations/hermes-agent) | Python | `cascadeflow` | Delegation router | No | No | Yes |
 
 ## Integration Patterns
 
@@ -35,6 +36,7 @@ from cascadeflow.integrations.openai_agents import CascadeFlowModelProvider
 from cascadeflow.integrations.crewai import enable as enable_crewai
 from cascadeflow.integrations.google_adk import enable as enable_adk
 from cascadeflow.integrations.pydantic_ai import create_cascade_model
+from cascadeflow.integrations.hermes import HermesDelegationRouter
 ```
 
 ### TypeScript
@@ -54,6 +56,7 @@ npm install @cascadeflow/n8n-nodes-cascadeflow
 - **PydanticAI**: Use if you're building with PydanticAI agents. The cascade `Model` performs drafter→verifier routing with quality gating and tool risk.
 - **n8n**: Use if you're building no-code workflows. The community node adds cascade routing to any n8n flow.
 - **Vercel AI SDK**: Use if you're building TypeScript server-side agents. The middleware wraps AI SDK streams.
+- **Hermes Agent**: Use if you need per-skill, complexity-aware, or topic-aware routing for delegated subagents while Hermes keeps provider credentials and fallback behavior.
 
 ## What Stays Consistent Across Frameworks
 

--- a/docs-site/why-cascadeflow.mdx
+++ b/docs-site/why-cascadeflow.mdx
@@ -113,7 +113,7 @@ Better economics and latency while preserving quality thresholds — not a trade
 
 ## 8. Why This Can Become a Category Leader
 
-- **Framework-neutral and provider-neutral** — works with LangChain, OpenAI Agents, CrewAI, Google ADK, Vercel AI, n8n, and custom frameworks
+- **Framework-neutral and provider-neutral** — works with LangChain, OpenAI Agents, CrewAI, Google ADK, Vercel AI, n8n, Hermes Agent, and custom frameworks
 - **Solves a structural gap** orchestration frameworks are not built or incentivized to solve
 - **Expands from optimization into business-intelligence control** for agents
 - **In-process architecture** is fundamentally better than proxy architecture for agent workloads

--- a/examples/integrations/hermes_delegation_router.py
+++ b/examples/integrations/hermes_delegation_router.py
@@ -1,0 +1,97 @@
+"""
+Standalone Hermes Agent delegation-routing example.
+
+This example does not import Hermes. It shows the small adapter shape a local
+Hermes wrapper, fork, or upstream PR can use before spawning a delegated child
+agent.
+"""
+
+from __future__ import annotations
+
+from cascadeflow.integrations.hermes import HermesDelegationRequest, HermesDelegationRouter
+
+ROUTER_CONFIG = {
+    "enabled": True,
+    "mode": "observe",
+    "min_confidence": 0.6,
+    "routes": {
+        "simple": {
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "reasoning_effort": "low",
+        },
+        "code": {
+            "provider": "nous",
+            "model": "nous/hermes-4.1",
+            "reasoning_effort": "high",
+        },
+        "research": {
+            "provider": "nous",
+            "model": "nous/hermes-research",
+            "reasoning_effort": "medium",
+        },
+        "finance": {
+            "provider": "anthropic",
+            "model": "claude-opus-4.1",
+            "reasoning_effort": "high",
+        },
+    },
+}
+
+
+def route_before_delegate_task(
+    *,
+    goal: str,
+    context: str | None = None,
+    toolsets: tuple[str, ...] = (),
+    loaded_skills: tuple[str, ...] = (),
+    skill_metadata: dict | None = None,
+    parent_provider: str | None = None,
+    parent_model: str | None = None,
+) -> dict:
+    """Return a Hermes-safe routing recommendation for a delegated task."""
+
+    router = HermesDelegationRouter.from_dict(ROUTER_CONFIG)
+    decision = router.route_delegation(
+        HermesDelegationRequest(
+            goal=goal,
+            context=context,
+            toolsets=toolsets,
+            loaded_skills=loaded_skills,
+            skill_metadata=skill_metadata,
+            parent_provider=parent_provider,
+            parent_model=parent_model,
+        )
+    )
+    return decision.to_dict()
+
+
+if __name__ == "__main__":
+    coding_decision = route_before_delegate_task(
+        goal="Debug the failing pytest regression and propose a patch",
+        context="The parent agent is working on a Python API client.",
+        toolsets=("terminal", "git"),
+        loaded_skills=("python", "debugging"),
+        parent_provider="openai",
+        parent_model="gpt-4.1-mini",
+    )
+    print("Coding subagent decision:")
+    print(coding_decision)
+
+    skill_decision = route_before_delegate_task(
+        goal="Review this indemnity clause for business risk",
+        loaded_skills=("contract-review",),
+        skill_metadata={
+            "cascadeflow": {
+                "provider": "anthropic",
+                "model": "claude-opus-4.1",
+                "reasoning_effort": "high",
+                "domain": "legal",
+                "topic": "contract-review",
+                "confidence": 0.99,
+            }
+        },
+    )
+    print("\nSkill-routed subagent decision:")
+    print(skill_decision)
+

--- a/tests/integrations/test_hermes_config.py
+++ b/tests/integrations/test_hermes_config.py
@@ -1,0 +1,56 @@
+from cascadeflow.integrations.hermes import HermesRouteProfile, HermesRoutingConfig
+from cascadeflow.integrations import HERMES_AVAILABLE, get_integration_info
+
+
+def test_routing_config_defaults_to_disabled_observe_mode():
+    config = HermesRoutingConfig.from_dict(None)
+
+    assert config.enabled is False
+    assert config.mode == "observe"
+    assert config.routes == {}
+
+
+def test_routing_config_sanitizes_invalid_values():
+    config = HermesRoutingConfig.from_dict(
+        {
+            "enabled": "yes",
+            "mode": "invalid",
+            "min_confidence": "not-a-number",
+            "route_provider_model": "false",
+            "routes": {
+                "code": {
+                    "provider": "nous",
+                    "model": "nous/hermes-4.1",
+                    "reasoning_effort": "turbo",
+                    "confidence": 2,
+                }
+            },
+        }
+    )
+
+    assert config.enabled is True
+    assert config.mode == "observe"
+    assert config.min_confidence == 0.6
+    assert config.route_provider_model is False
+    assert config.routes["code"].reasoning_effort is None
+    assert config.routes["code"].confidence == 1.0
+
+
+def test_route_profile_accepts_known_reasoning_effort():
+    profile = HermesRouteProfile.from_dict(
+        {
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "reasoning_effort": "LOW",
+        }
+    )
+
+    assert profile.reasoning_effort == "low"
+
+
+def test_hermes_integration_is_discoverable():
+    info = get_integration_info()
+
+    assert HERMES_AVAILABLE is True
+    assert info["hermes_available"] is True
+    assert info["capabilities"]["hermes"] is True

--- a/tests/integrations/test_hermes_router.py
+++ b/tests/integrations/test_hermes_router.py
@@ -1,0 +1,303 @@
+import pytest
+
+from cascadeflow.integrations.hermes import (
+    HermesDelegationRequest,
+    HermesDelegationRouter,
+    HermesRouteProfile,
+    HermesRoutingConfig,
+    HermesTaskClassification,
+)
+
+
+class StaticClassifier:
+    def __init__(
+        self,
+        *,
+        domain="code",
+        complexity="moderate",
+        confidence=0.8,
+        reason="static",
+        topic=None,
+    ):
+        self.classification = HermesTaskClassification(
+            domain=domain,
+            complexity=complexity,
+            confidence=confidence,
+            reason=reason,
+            topic=topic,
+        )
+
+    def classify(self, request):
+        return self.classification
+
+
+class FailingClassifier:
+    def classify(self, request):
+        raise RuntimeError("classification failed")
+
+
+def _router(config, **classification):
+    return HermesDelegationRouter(
+        config=HermesRoutingConfig.from_dict(config),
+        classifier=StaticClassifier(**classification),
+    )
+
+
+def _request(**kwargs):
+    return HermesDelegationRequest(
+        goal=kwargs.pop("goal", "Implement a typed API client and unit tests"),
+        toolsets=kwargs.pop("toolsets", ("terminal", "git")),
+        loaded_skills=kwargs.pop("loaded_skills", ("python",)),
+        **kwargs,
+    )
+
+
+def test_disabled_config_returns_inherit_decision():
+    router = _router({"enabled": False})
+
+    decision = router.route_delegation(_request())
+
+    assert decision.action == "inherit"
+    assert decision.reason == "cascadeflow_disabled"
+    assert decision.applies is False
+
+
+def test_observe_mode_returns_recommendation_without_applying_it():
+    router = _router(
+        {
+            "enabled": True,
+            "mode": "observe",
+            "routes": {
+                "code": {
+                    "provider": "nous",
+                    "model": "nous/hermes-4.1",
+                    "reasoning_effort": "high",
+                }
+            },
+        }
+    )
+
+    decision = router.route_delegation(_request())
+
+    assert decision.action == "inherit"
+    assert decision.provider == "nous"
+    assert decision.model == "nous/hermes-4.1"
+    assert decision.reasoning_effort == "high"
+    assert decision.metadata["mode"] == "observe"
+    assert decision.metadata["would_route"] is True
+    assert decision.metadata["applied"] is False
+
+
+def test_route_mode_applies_matching_domain_profile():
+    router = _router(
+        {
+            "enabled": True,
+            "mode": "route",
+            "routes": {
+                "code": {
+                    "provider": "nous",
+                    "model": "nous/hermes-4.1",
+                    "reasoning_effort": "high",
+                }
+            },
+        },
+        domain="code",
+        complexity="hard",
+        confidence=0.91,
+        topic="code",
+    )
+
+    decision = router.route_delegation(_request())
+
+    assert decision.action == "route"
+    assert decision.provider == "nous"
+    assert decision.model == "nous/hermes-4.1"
+    assert decision.domain == "code"
+    assert decision.complexity == "hard"
+    assert decision.confidence == pytest.approx(0.91)
+    assert decision.metadata["loaded_skills"] == ["python"]
+
+
+def test_debugging_domain_can_use_code_route():
+    router = _router(
+        {
+            "enabled": True,
+            "mode": "route",
+            "routes": {
+                "code": {
+                    "provider": "nous",
+                    "model": "nous/hermes-4.1",
+                    "reasoning_effort": "high",
+                }
+            },
+        },
+        domain="debugging",
+        complexity="hard",
+        confidence=0.9,
+        topic="debugging",
+    )
+
+    decision = router.route_delegation(_request(goal="Debug the failing regression"))
+
+    assert decision.action == "route"
+    assert decision.domain == "debugging"
+    assert decision.topic == "debugging"
+    assert decision.model == "nous/hermes-4.1"
+
+
+def test_skill_metadata_profile_takes_precedence_over_classifier():
+    router = _router(
+        {
+            "enabled": True,
+            "mode": "route",
+            "routes": {
+                "simple": {
+                    "provider": "openai",
+                    "model": "gpt-4.1-mini",
+                    "reasoning_effort": "low",
+                }
+            },
+        },
+        domain="simple",
+        complexity="simple",
+        confidence=0.7,
+    )
+    request = _request(
+        skill_metadata={
+            "cascadeflow": {
+                "provider": "anthropic",
+                "model": "claude-opus-4.1",
+                "reasoning_effort": "high",
+                "domain": "legal",
+                "topic": "contract-review",
+                "confidence": 0.99,
+            }
+        }
+    )
+
+    decision = router.route_delegation(request)
+
+    assert decision.action == "route"
+    assert decision.source == "skill_metadata"
+    assert decision.provider == "anthropic"
+    assert decision.model == "claude-opus-4.1"
+    assert decision.domain == "legal"
+    assert decision.topic == "contract-review"
+
+
+def test_simple_complexity_uses_simple_route():
+    router = _router(
+        {
+            "enabled": True,
+            "mode": "route",
+            "routes": {
+                "simple": {
+                    "provider": "openai",
+                    "model": "gpt-4.1-mini",
+                    "reasoning_effort": "low",
+                }
+            },
+        },
+        domain="general",
+        complexity="simple",
+        confidence=0.73,
+    )
+
+    decision = router.route_delegation(_request(goal="Rename this variable"))
+
+    assert decision.action == "route"
+    assert decision.model == "gpt-4.1-mini"
+    assert decision.complexity == "simple"
+
+
+def test_high_stakes_domain_without_matching_route_inherits():
+    router = _router(
+        {
+            "enabled": True,
+            "mode": "route",
+            "routes": {
+                "code": {
+                    "provider": "nous",
+                    "model": "nous/hermes-4.1",
+                }
+            },
+        },
+        domain="medical",
+        complexity="hard",
+        confidence=0.86,
+    )
+
+    decision = router.route_delegation(_request(goal="Review this patient diagnosis note"))
+
+    assert decision.action == "inherit"
+    assert decision.reason == "high_stakes_domain_unconfigured"
+    assert decision.domain == "medical"
+
+
+def test_confidence_below_threshold_inherits_but_keeps_audit_recommendation():
+    router = _router(
+        {
+            "enabled": True,
+            "mode": "route",
+            "min_confidence": 0.9,
+            "routes": {
+                "research": {
+                    "provider": "nous",
+                    "model": "nous/hermes-research",
+                    "reasoning_effort": "medium",
+                }
+            },
+        },
+        domain="research",
+        complexity="moderate",
+        confidence=0.74,
+    )
+
+    decision = router.route_delegation(_request(goal="Research the current market"))
+
+    assert decision.action == "inherit"
+    assert decision.reason == "confidence_below_threshold"
+    assert decision.model == "nous/hermes-research"
+    assert decision.metadata["would_route"] is True
+    assert decision.metadata["applied"] is False
+
+
+def test_route_provider_model_can_be_disabled_independently():
+    router = _router(
+        {
+            "enabled": True,
+            "mode": "route",
+            "route_provider_model": False,
+            "routes": {
+                "code": {
+                    "provider": "nous",
+                    "model": "nous/hermes-4.1",
+                    "reasoning_effort": "high",
+                }
+            },
+        }
+    )
+
+    decision = router.route_delegation(_request())
+
+    assert decision.action == "route"
+    assert decision.provider is None
+    assert decision.model is None
+    assert decision.reasoning_effort == "high"
+
+
+def test_router_never_raises_on_classifier_failure():
+    router = HermesDelegationRouter(
+        config=HermesRoutingConfig(
+            enabled=True,
+            mode="route",
+            routes={"code": HermesRouteProfile(provider="nous", model="x")},
+        ),
+        classifier=FailingClassifier(),
+    )
+
+    decision = router.route_delegation(_request())
+
+    assert decision.action == "inherit"
+    assert decision.reason == "router_error"
+    assert decision.metadata["error"] == "RuntimeError"

--- a/tests/integrations/test_hermes_skill_metadata.py
+++ b/tests/integrations/test_hermes_skill_metadata.py
@@ -1,0 +1,50 @@
+from cascadeflow.integrations.hermes import (
+    extract_cascadeflow_skill_metadata,
+    profile_from_skill_metadata,
+)
+
+
+def test_extracts_direct_cascadeflow_skill_metadata():
+    metadata = {
+        "name": "python-code",
+        "cascadeflow": {
+            "provider": "nous",
+            "model": "nous/hermes-4.1",
+            "reasoning_effort": "high",
+            "domain": "code",
+        },
+    }
+
+    block = extract_cascadeflow_skill_metadata(metadata)
+
+    assert block["provider"] == "nous"
+    assert block["model"] == "nous/hermes-4.1"
+
+
+def test_extracts_nested_hermes_cascadeflow_metadata():
+    metadata = {
+        "metadata": {
+            "hermes": {
+                "cascadeflow": {
+                    "provider": "openai",
+                    "model": "gpt-4.1-mini",
+                    "reasoning_effort": "low",
+                    "domain": "research",
+                }
+            }
+        }
+    }
+
+    profile = profile_from_skill_metadata(metadata)
+
+    assert profile is not None
+    assert profile.provider == "openai"
+    assert profile.model == "gpt-4.1-mini"
+    assert profile.reasoning_effort == "low"
+    assert profile.domain == "research"
+
+
+def test_missing_skill_metadata_returns_no_profile():
+    assert extract_cascadeflow_skill_metadata({"name": "plain-skill"}) == {}
+    assert profile_from_skill_metadata({"name": "plain-skill"}) is None
+


### PR DESCRIPTION
## Summary

Adds `cascadeflow.integrations.hermes` — an optional integration that lets [Hermes](https://github.com/NousResearch/hermes-agent) delegate per-child routing decisions to CascadeFlow while Hermes retains full ownership of credentials, base URLs, fallback chains, and `api_mode`.

- New package: `cascadeflow/integrations/hermes/` — `router.py`, `classifier.py`, `config.py`, `skill_metadata.py`, `types.py`, plus package `README.md`
- Registered in `cascadeflow/integrations/__init__.py`; `HermesDelegationRouter` re-exported from the top-level package
- Docs: new `docs-site/integrations/hermes-agent.mdx`, plus updates to overview, changelog, choose-integration, index, why-cascadeflow, and root README
- Example: `examples/integrations/hermes_delegation_router.py`
- Tests: 17 new tests in `tests/integrations/test_hermes_{config,router,skill_metadata}.py` — all green

## Design

The integration is optional from both sides. Hermes lazy-imports `cascadeflow.integrations.hermes` and falls back to its native delegation behavior if the package isn't installed. CascadeFlow returns routing *decisions* (provider/model/reasoning_effort/confidence + audit metadata); the consumer decides whether to apply them. Hermes layers its own `min_confidence`, per-dimension toggles (`route_provider_model`, `route_reasoning_effort`), and `_static_delegation_route_configured` precedence on top.

## Companion PR

[NousResearch/hermes-agent#26564](https://github.com/NousResearch/hermes-agent/pull/26564) consumes this integration. The hermes-side PR is ready for review.

## Test plan

- [x] `pytest tests/integrations/` — 17 passed
- [x] `pytest tests/` (full suite) — 1240 passed, 98 skipped
- [ ] Reviewer to verify docs render correctly on docs-site preview