### PR TITLE
docs(readme): promote Hermes integration to callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@
 
 cascadeflow works where external proxies can't: per-step model decisions based on agent state, per-tool-call budget gating, runtime stop/continue/escalate actions, and business KPI injection during agent loops. It accumulates insight from every model call, tool result, and quality score — the agent gets smarter the more it runs. Sub-5ms overhead. Works with LangChain, OpenAI Agents SDK, CrewAI, PydanticAI, Google ADK, n8n, Vercel AI SDK, and Hermes Agent.
 
-**New: Hermes Agent delegation routing.** CascadeFlow now provides a Hermes Agent integration for per-skill model routing, task-complexity routing, topic-aware subagent routing, observe-mode rollout, and auditable decisions without taking over provider credentials, base URLs, fallback chains, or API modes. It is built as an optional integration surface, like n8n or Vercel AI SDK, so Hermes can keep its core runtime behavior while CascadeFlow supplies routing intelligence.
+> [!IMPORTANT]
+> ### New: Hermes Agent delegation routing
+>
+> CascadeFlow now provides a Hermes Agent integration for per-skill model routing, task-complexity routing, topic-aware subagent routing, observe-mode rollout, and auditable decisions without taking over provider credentials, base URLs, fallback chains, or API modes.
 
 ```bash
 pip install cascadeflow


### PR DESCRIPTION
Promotes the Hermes integration mention in the main README to a GitHub `[!IMPORTANT]` callout so it stands out from the surrounding pitch text, and trims the trailing positioning sentence ("It is built as an optional integration surface, like n8n or Vercel AI SDK...") to keep the block tight.