### PR TITLE
docs(readme): label Hermes section as Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@
 
 cascadeflow works where external proxies can't: per-step model decisions based on agent state, per-tool-call budget gating, runtime stop/continue/escalate actions, and business KPI injection during agent loops. It accumulates insight from every model call, tool result, and quality score — the agent gets smarter the more it runs. Sub-5ms overhead. Works with LangChain, OpenAI Agents SDK, CrewAI, PydanticAI, Google ADK, n8n, Vercel AI SDK, and Hermes Agent.
 
-> [!IMPORTANT]
-> ### New: Hermes Agent delegation routing
+> **Update**
+> ### Hermes Agent delegation routing
 >
 > CascadeFlow now provides a Hermes Agent integration for per-skill model routing, task-complexity routing, topic-aware subagent routing, observe-mode rollout, and auditable decisions without taking over provider credentials, base URLs, fallback chains, or API modes.
 


### PR DESCRIPTION
Swaps the `[!IMPORTANT]` callout label to a bold "Update" prefix on the Hermes Agent section.

Note: GitHub's alert syntax only supports `NOTE | TIP | IMPORTANT | WARNING | CAUTION` — no `[!UPDATE]`. Dropping the alert tag in favor of a styled blockquote keeps the standout (blockquote indent + bold label) while showing the word "Update" as requested.