### PR TITLE
fix: make Tests CI green (py3.9 collection + Hermes classifier determinism)

### DIFF
--- a/cascadeflow/integrations/hermes/classifier.py
+++ b/cascadeflow/integrations/hermes/classifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Optional
 
@@ -122,10 +123,17 @@ class HermesTaskClassifier:
             reason=domain_reason,
         )
 
+    @staticmethod
+    def _keyword_in_text(keyword: str, lowered: str) -> bool:
+        # Match on word boundaries so short keywords (e.g. "ci", "api", "law")
+        # don't match inside unrelated words like "financial" ("ci") or "always"
+        # ("law"). Handles multi-word keywords ("stack trace") correctly too.
+        return re.search(rf"\b{re.escape(keyword)}\b", lowered) is not None
+
     def _detect_domain(self, lowered: str, toolsets: tuple[str, ...]) -> tuple[str, float, str]:
         scores: dict[str, int] = {}
         for domain, keywords in DOMAIN_KEYWORDS.items():
-            hits = sum(1 for keyword in keywords if keyword in lowered)
+            hits = sum(1 for keyword in keywords if self._keyword_in_text(keyword, lowered))
             if hits:
                 scores[domain] = hits
 

--- a/tests/test_provider_tool_retry.py
+++ b/tests/test_provider_tool_retry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 
 from cascadeflow.providers.base import BaseProvider, ModelResponse, RetryConfig


### PR DESCRIPTION
## Why

The **Tests** badge on `main` has been red. Two independent failures in the `test.yml` Python matrix:

1. **Collection error (Python 3.9 leg)** — `tests/test_provider_tool_retry.py`
   `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`
   The file used `str | None` in method signatures. Python 3.9 evaluates annotations at definition time, so this raised at import → the whole file failed to collect. (3.10+ legs were unaffected.)

2. **Nondeterministic failure** — `tests/integrations/test_hermes_classifier.py::test_high_stakes_domains_are_detected`
   `AssertionError: assert 'ops' == 'finance'`
   The test picks a keyword via `next(iter(DOMAIN_KEYWORDS[domain]))` on a **set**, so the choice depends on `PYTHONHASHSEED` and varies per CI run. When it picked `"financial"`, the classifier's naive substring match `"ci" in lowered` matched the `ci` inside "finan**ci**al", giving the **ops** domain a tying hit that won on dict order. Red only on unlucky seeds.

## Fix

1. Add `from __future__ import annotations` to `test_provider_tool_retry.py` (defers annotation eval; matches the rest of the suite — 40+ files already do this).
2. Match domain keywords on **word boundaries** in `HermesTaskClassifier` so short keywords (`ci`, `api`, `law`) no longer match inside unrelated words. This fixes the real over-matching bug *and* makes the test deterministic. Multi-word keywords (`stack trace`, `pull request`) still match.

## Verification (local, Python 3.9.6 — the affected leg)

- Exact CI command: `pytest tests/ -m "not integration and not requires_api and not requires_ollama and not requires_vllm"` → **1332 passed, 12 skipped, 59 deselected, 0 failed**.
- `test_high_stakes_domains_are_detected` passes across `PYTHONHASHSEED` = 0/1/2/42/123 (was seed-dependent before).
- Lint job clean on changed files: `black==25.11.0 --check` ✓, `ruff==0.15.0 check` ✓, `mypy --ignore-missing-imports` ✓.

Two focused commits; no behavior change beyond the classifier keyword-matching correctness.