### PR TITLE
Add Atlas Cloud provider

### DIFF
--- a/cascadeflow/providers/__init__.py
+++ b/cascadeflow/providers/__init__.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 _LAZY_PROVIDERS: dict[str, str] = {
     "AnthropicProvider": ".anthropic",
+    "AtlasCloudProvider": ".atlascloud",
     "DeepSeekProvider": ".deepseek",
     "GroqProvider": ".groq",
     "HuggingFaceProvider": ".huggingface",
@@ -57,6 +58,7 @@ def _build_provider_registry() -> dict:
     registry = {}
     _name_to_key = {
         "OpenAIProvider": "openai",
+        "AtlasCloudProvider": "atlascloud",
         "AnthropicProvider": "anthropic",
         "OllamaProvider": "ollama",
         "GroqProvider": "groq",
@@ -137,6 +139,7 @@ __all__ = [
     "ModelResponse",
     "PROVIDER_CAPABILITIES",
     "OpenAIProvider",
+    "AtlasCloudProvider",
     "AnthropicProvider",
     "OllamaProvider",
     "GroqProvider",

--- a/cascadeflow/providers/atlascloud.py
+++ b/cascadeflow/providers/atlascloud.py
@@ -1,0 +1,53 @@
+"""Atlas Cloud provider implementation.
+
+Atlas Cloud exposes an OpenAI-compatible chat completions API, so the provider
+reuses the OpenAI provider implementation with Atlas-specific defaults.
+
+Environment Variables:
+    ATLASCLOUD_API_KEY: Your Atlas Cloud API key
+
+Models:
+    - qwen/qwen3.5-flash: Fast default chat model
+    - deepseek-ai/deepseek-v4-pro: Reasoning-capable chat model
+"""
+
+import os
+from typing import Optional
+
+from .openai import OpenAIProvider
+
+
+class AtlasCloudProvider(OpenAIProvider):
+    """Atlas Cloud provider using the OpenAI-compatible API."""
+
+    BASE_URL = "https://api.atlascloud.ai/v1"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        Initialize Atlas Cloud provider.
+
+        Args:
+            api_key: Atlas Cloud API key (defaults to ATLASCLOUD_API_KEY env var)
+            base_url: Custom base URL (defaults to Atlas Cloud API)
+            **kwargs: Additional OpenAI provider options
+        """
+        atlascloud_api_key = api_key or os.getenv("ATLASCLOUD_API_KEY")
+
+        if not atlascloud_api_key:
+            raise ValueError(
+                "Atlas Cloud API key not found. "
+                "Set ATLASCLOUD_API_KEY environment variable or pass api_key parameter."
+            )
+
+        super().__init__(api_key=atlascloud_api_key, **kwargs)
+        self.base_url = base_url or self.BASE_URL
+
+    @property
+    def name(self) -> str:
+        """Provider name."""
+        return "atlascloud"

--- a/cascadeflow/providers/atlascloud.py
+++ b/cascadeflow/providers/atlascloud.py
@@ -12,8 +12,10 @@ Models:
 """
 
 import os
-from typing import Optional
+from typing import Any, Optional
 
+from ..exceptions import ModelError, ProviderError
+from .base import ModelResponse
 from .openai import OpenAIProvider
 
 
@@ -46,8 +48,69 @@ class AtlasCloudProvider(OpenAIProvider):
 
         super().__init__(api_key=atlascloud_api_key, **kwargs)
         self.base_url = base_url or self.BASE_URL
+        # Atlas pricing is not represented by LiteLLM's OpenAI model catalog.
+        # Report untracked cost instead of attributing OpenAI estimates.
+        self._litellm_cost_provider = None
+        self._use_litellm_pricing = False
+        self._litellm_provider_prefix = None
 
     @property
     def name(self) -> str:
         """Provider name."""
         return "atlascloud"
+
+    def _check_logprobs_support(self) -> bool:
+        """Atlas Cloud does not currently guarantee OpenAI logprobs semantics."""
+        return False
+
+    def _get_litellm_prefix(self) -> Optional[str]:
+        """Atlas model IDs must not be rewritten as OpenAI model IDs."""
+        return None
+
+    def estimate_cost(
+        self,
+        tokens: int,
+        model: str,
+        prompt_tokens: Optional[int] = None,
+        completion_tokens: Optional[int] = None,
+    ) -> float:
+        """Return an explicit untracked cost until Atlas pricing is available locally."""
+        return 0.0
+
+    def _attribute_error(self, error: Exception) -> None:
+        if isinstance(error, (ProviderError, ModelError)):
+            error.provider = self.name
+            error.args = (str(error).replace("OpenAI", "Atlas Cloud"),)
+
+    async def _complete_impl(
+        self,
+        prompt: str,
+        model: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        system_prompt: Optional[str] = None,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        try:
+            response = await super()._complete_impl(
+                prompt=prompt,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                system_prompt=system_prompt,
+                **kwargs,
+            )
+        except (ProviderError, ModelError) as error:
+            self._attribute_error(error)
+            raise
+        response.provider = self.name
+        return response
+
+    async def complete_with_tools(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        try:
+            response = await super().complete_with_tools(*args, **kwargs)
+        except (ProviderError, ModelError) as error:
+            self._attribute_error(error)
+            raise
+        response.provider = self.name
+        return response

--- a/cascadeflow/providers/base.py
+++ b/cascadeflow/providers/base.py
@@ -947,6 +947,7 @@ class BaseProvider(ABC):
         # Map provider class names to LiteLLM prefixes
         provider_prefixes = {
             "OpenAIProvider": None,  # Native format
+            "AtlasCloudProvider": "openai",  # Atlas Cloud uses OpenAI-compatible format
             "AnthropicProvider": None,  # Native format
             "GroqProvider": "groq",
             "TogetherProvider": "together_ai",

--- a/cascadeflow/providers/base.py
+++ b/cascadeflow/providers/base.py
@@ -1615,6 +1615,13 @@ PROVIDER_CAPABILITIES = {
         "max_top_logprobs": 20,
         "has_cost_tracking": True,
     },
+    "atlascloud": {
+        "supports_logprobs": False,
+        "supports_streaming": True,
+        "supports_tools": True,
+        "max_top_logprobs": 0,
+        "has_cost_tracking": False,
+    },
     "groq": {
         "supports_logprobs": False,
         "supports_streaming": True,

--- a/cascadeflow/schema/config.py
+++ b/cascadeflow/schema/config.py
@@ -110,6 +110,7 @@ class ModelConfig(BaseModel):
         v = v.lower()
         allowed = [
             "openai",
+            "atlascloud",
             "anthropic",
             "groq",
             "ollama",

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -184,6 +184,7 @@ python examples/multi_provider.py
 | pydantic | Core validation | ✅ Always | requirements.txt |
 | httpx | Core HTTP client | ✅ Always | requirements.txt |
 | openai | OpenAIProvider | ❌ Optional | `[openai]` or `[providers]` or `[all]` |
+| atlascloud | AtlasCloudProvider | ❌ Optional | core package + `ATLASCLOUD_API_KEY` |
 | anthropic | AnthropicProvider | ❌ Optional | `[anthropic]` or `[providers]` or `[all]` |
 | groq | GroqProvider | ❌ Optional | `[groq]` or `[providers]` or `[all]` |
 | huggingface-hub | HuggingFaceProvider | ❌ Optional | `[huggingface]` or `[all]` |

--- a/tests/test_atlascloud.py
+++ b/tests/test_atlascloud.py
@@ -1,12 +1,15 @@
 """Tests for Atlas Cloud provider."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
 
-from cascadeflow.providers import PROVIDER_REGISTRY
+from cascadeflow.exceptions import ProviderError
+from cascadeflow.providers import PROVIDER_CAPABILITIES, PROVIDER_REGISTRY
 from cascadeflow.providers.atlascloud import AtlasCloudProvider
+from cascadeflow.schema.config import ModelConfig
 
 
 def test_init_with_api_key():
@@ -44,3 +47,60 @@ def test_custom_base_url():
 def test_registered_provider():
     """Test Atlas Cloud is registered for cascade agents."""
     assert PROVIDER_REGISTRY["atlascloud"] is AtlasCloudProvider
+
+
+def test_model_config_and_capabilities():
+    config = ModelConfig(name="qwen/qwen3.5-flash", provider="atlascloud", cost=0)
+
+    assert config.provider == "atlascloud"
+    assert PROVIDER_CAPABILITIES["atlascloud"] == {
+        "supports_logprobs": False,
+        "supports_streaming": True,
+        "supports_tools": True,
+        "max_top_logprobs": 0,
+        "has_cost_tracking": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_registry_provider_response_attribution():
+    config = ModelConfig(name="qwen/qwen3.5-flash", provider="atlascloud", cost=0)
+    provider = PROVIDER_REGISTRY[config.provider](api_key="atlas-test-key")
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+    }
+    provider.client.post = AsyncMock(return_value=response)
+
+    result = await provider.complete(prompt="hello", model=config.name, logprobs=False)
+
+    assert provider.client.post.await_args.args[0] == (
+        "https://api.atlascloud.ai/v1/chat/completions"
+    )
+    assert result.provider == "atlascloud"
+    assert result.cost == 0.0
+
+
+@pytest.mark.asyncio
+async def test_error_attribution_uses_atlascloud():
+    provider = AtlasCloudProvider(api_key="atlas-test-key")
+    request = httpx.Request("POST", "https://api.atlascloud.ai/v1/chat/completions")
+    response = httpx.Response(401, request=request)
+    provider.client.post = AsyncMock(return_value=response)
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.complete(prompt="hello", model="qwen/qwen3.5-flash", logprobs=False)
+
+    assert exc_info.value.provider == "atlascloud"
+    assert "Atlas Cloud" in str(exc_info.value)
+
+
+def test_cost_is_explicitly_untracked():
+    provider = AtlasCloudProvider(api_key="atlas-test-key")
+
+    assert provider._use_litellm_pricing is False
+    assert provider.calculate_accurate_cost(
+        model="qwen/qwen3.5-flash", prompt_tokens=100, completion_tokens=50
+    ) == 0.0

--- a/tests/test_atlascloud.py
+++ b/tests/test_atlascloud.py
@@ -1,0 +1,46 @@
+"""Tests for Atlas Cloud provider."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cascadeflow.providers import PROVIDER_REGISTRY
+from cascadeflow.providers.atlascloud import AtlasCloudProvider
+
+
+def test_init_with_api_key():
+    """Test initialization with explicit API key."""
+    provider = AtlasCloudProvider(api_key="atlas-test-key")
+
+    assert provider.api_key == "atlas-test-key"
+    assert provider.base_url == "https://api.atlascloud.ai/v1"
+    assert provider.name == "atlascloud"
+
+
+def test_init_from_env():
+    """Test initialization from ATLASCLOUD_API_KEY."""
+    with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "atlas-env-key"}, clear=True):
+        provider = AtlasCloudProvider()
+
+    assert provider.api_key == "atlas-env-key"
+    assert provider.base_url == "https://api.atlascloud.ai/v1"
+
+
+def test_init_no_api_key():
+    """Test initialization fails without Atlas Cloud API key."""
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="Atlas Cloud API key not found"):
+            AtlasCloudProvider()
+
+
+def test_custom_base_url():
+    """Test custom Atlas Cloud-compatible base URL."""
+    provider = AtlasCloudProvider(api_key="atlas-test-key", base_url="https://proxy.test/v1")
+
+    assert provider.base_url == "https://proxy.test/v1"
+
+
+def test_registered_provider():
+    """Test Atlas Cloud is registered for cascade agents."""
+    assert PROVIDER_REGISTRY["atlascloud"] is AtlasCloudProvider

--- a/tests/test_atlascloud.py
+++ b/tests/test_atlascloud.py
@@ -101,6 +101,9 @@ def test_cost_is_explicitly_untracked():
     provider = AtlasCloudProvider(api_key="atlas-test-key")
 
     assert provider._use_litellm_pricing is False
-    assert provider.calculate_accurate_cost(
-        model="qwen/qwen3.5-flash", prompt_tokens=100, completion_tokens=50
-    ) == 0.0
+    assert (
+        provider.calculate_accurate_cost(
+            model="qwen/qwen3.5-flash", prompt_tokens=100, completion_tokens=50
+        )
+        == 0.0
+    )


### PR DESCRIPTION
## Summary
- add an Atlas Cloud provider that reuses the existing OpenAI-compatible provider path
- register `atlascloud` in the provider registry and LiteLLM prefix mapping
- document the provider dependency row and add focused provider tests

## Validation
- `python3 -m pytest -o addopts='' tests/test_atlascloud.py tests/test_agent_module_callable.py -q`
- `python3 -m compileall cascadeflow/providers/atlascloud.py cascadeflow/providers/__init__.py cascadeflow/providers/base.py tests/test_atlascloud.py`
- `git diff --check`
- Atlas live catalog returned `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

Notes: local environment does not have `ruff` or `black` installed, so those checks could not be run here.

README: no README changes; docs update only, no sponsor/logo/credits/partner promotion.