### PR TITLE
Add portable MCP Apps routing panel

### DIFF
--- a/cascadeflow/integrations/mcp.py
+++ b/cascadeflow/integrations/mcp.py
@@ -48,6 +48,7 @@ def create_mcp_server(
     knowledge_resolver: Optional[KnowledgeResolver] = None,
     name: str = "cascadeflow",
     max_context_chars: int = 12_000,
+    include_ui: bool = False,
 ) -> Any:
     """Create a tool-first MCP server backed by a configured ``CascadeAgent``.
 
@@ -71,6 +72,31 @@ def create_mcp_server(
         json_response=True,
     )
 
+    tool_meta = None
+    if include_ui:
+        from .mcp_app import ROUTING_APP_HTML, ROUTING_APP_MIME_TYPE, ROUTING_APP_URI
+
+        tool_meta = {
+            "ui": {"resourceUri": ROUTING_APP_URI},
+            "openai/outputTemplate": ROUTING_APP_URI,
+        }
+
+        @server.resource(
+            ROUTING_APP_URI,
+            name="cascadeflow-route",
+            title="cascadeflow route",
+            description="Compact routing, cost, latency, and knowledge-version trace.",
+            mime_type=ROUTING_APP_MIME_TYPE,
+            meta={
+                "ui": {
+                    "prefersBorder": True,
+                    "csp": {"connectDomains": [], "resourceDomains": []},
+                }
+            },
+        )
+        def cascadeflow_route_app() -> str:
+            return ROUTING_APP_HTML
+
     @server.tool(
         title="Run cascadeflow",
         annotations={
@@ -78,6 +104,7 @@ def create_mcp_server(
             "destructiveHint": False,
             "openWorldHint": True,
         },
+        meta=tool_meta,
     )
     async def cascadeflow_run(
         query: str,

--- a/cascadeflow/integrations/mcp_app.py
+++ b/cascadeflow/integrations/mcp_app.py
@@ -1,0 +1,198 @@
+"""Self-contained MCP Apps view for cascadeflow routing results."""
+
+from __future__ import annotations
+
+ROUTING_APP_URI = "ui://cascadeflow/route-v1.html"
+ROUTING_APP_MIME_TYPE = "text/html;profile=mcp-app"
+
+ROUTING_APP_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>cascadeflow route</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f8fafc;
+      --card: #ffffff;
+      --text: #172033;
+      --muted: #64748b;
+      --line: #dbe3ee;
+      --accent: #0f766e;
+      --accent-soft: #ccfbf1;
+      --good: #15803d;
+    }
+    :root[data-theme="dark"] {
+      --bg: #10151f;
+      --card: #171e2b;
+      --text: #ecf3ff;
+      --muted: #9cabc1;
+      --line: #2c384c;
+      --accent: #5eead4;
+      --accent-soft: #123c3a;
+      --good: #86efac;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 12px;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .shell {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--card);
+    }
+    .header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+    .brand { font-weight: 750; letter-spacing: -.02em; }
+    .badge {
+      padding: 4px 9px;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .summary { margin: 12px 0 0; color: var(--muted); }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+      margin-top: 14px;
+    }
+    .metric { min-width: 0; padding: 10px; border: 1px solid var(--line); border-radius: 12px; }
+    .label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .05em; }
+    .value { margin-top: 4px; overflow-wrap: anywhere; font-weight: 700; }
+    .value.good { color: var(--good); }
+    .details {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 6px 12px;
+      margin-top: 14px;
+      padding-top: 12px;
+      border-top: 1px solid var(--line);
+      font-size: 12px;
+    }
+    .details dt { color: var(--muted); }
+    .details dd { margin: 0; overflow-wrap: anywhere; text-align: right; }
+    .foot { margin-top: 12px; color: var(--muted); font-size: 11px; }
+    @media (max-width: 560px) { .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+  </style>
+</head>
+<body>
+  <main class="shell" aria-live="polite">
+    <div class="header">
+      <div class="brand">cascadeflow</div>
+      <div class="badge" id="status">Routing…</div>
+    </div>
+    <p class="summary" id="summary">Waiting for the cost-aware route result.</p>
+    <section class="grid" aria-label="Route metrics">
+      <div class="metric"><div class="label">Model</div><div class="value" id="model">—</div></div>
+      <div class="metric"><div class="label">Cost</div><div class="value" id="cost">—</div></div>
+      <div class="metric"><div class="label">Saved</div><div class="value good" id="saved">—</div></div>
+      <div class="metric"><div class="label">Latency</div><div class="value" id="latency">—</div></div>
+    </section>
+    <dl class="details">
+      <dt>Strategy</dt><dd id="strategy">—</dd>
+      <dt>Knowledge</dt><dd id="knowledge">None selected</dd>
+    </dl>
+    <div class="foot">Knowledge is resolved server-side and is not embedded in this view.</div>
+  </main>
+  <script>
+    (() => {
+      const byId = (id) => document.getElementById(id);
+      let initialized = false;
+      const money = (value) => Number.isFinite(Number(value))
+        ? "$" + Number(value).toFixed(Number(value) < 0.01 ? 6 : 4)
+        : "—";
+      const text = (id, value) => { byId(id).textContent = value ?? "—"; };
+
+      function applyHostContext(context) {
+        if (context && context.theme) document.documentElement.dataset.theme = context.theme;
+      }
+
+      function structuredResult(result) {
+        if (result && result.structuredContent) return result.structuredContent;
+        const block = result && Array.isArray(result.content) && result.content.find((x) => x.type === "text");
+        if (!block) return null;
+        try { return JSON.parse(block.text); } catch (_) { return null; }
+      }
+
+      function render(result) {
+        const data = structuredResult(result);
+        if (!data) {
+          text("status", "Unavailable");
+          text("summary", "The route completed without a structured trace.");
+          return;
+        }
+        const accepted = data.draft_accepted === true;
+        text("status", accepted ? "Draft accepted" : (data.cascaded ? "Escalated" : "Complete"));
+        text("summary", accepted
+          ? "The lower-cost draft met the quality threshold."
+          : (data.cascaded ? "cascadeflow escalated to protect answer quality." : "The route completed directly."));
+        text("model", data.model_used);
+        text("cost", money(data.total_cost));
+        text("saved", money(data.cost_saved));
+        text("latency", Number.isFinite(Number(data.latency_ms)) ? Math.round(Number(data.latency_ms)) + " ms" : "—");
+        text("strategy", data.routing_strategy);
+        const knowledge = data.knowledge || {};
+        text("knowledge", knowledge.identity || knowledge.key || "None selected");
+        sendSize();
+      }
+
+      function post(message) { window.parent.postMessage(message, "*"); }
+      function sendSize() {
+        if (!initialized) return;
+        post({
+          jsonrpc: "2.0",
+          method: "ui/notifications/size-changed",
+          params: { height: document.documentElement.scrollHeight }
+        });
+      }
+
+      window.addEventListener("message", (event) => {
+        if (event.source !== window.parent || !event.data || event.data.jsonrpc !== "2.0") return;
+        const message = event.data;
+        if (message.id === "cascadeflow-init" && message.result) {
+          applyHostContext(message.result.hostContext);
+          post({ jsonrpc: "2.0", method: "ui/notifications/initialized" });
+          initialized = true;
+          sendSize();
+        } else if (message.method === "ui/notifications/host-context-changed") {
+          applyHostContext(message.params);
+        } else if (message.method === "ui/notifications/tool-input") {
+          text("status", "Routing…");
+        } else if (message.method === "ui/notifications/tool-result") {
+          render(message.params);
+        } else if (message.method === "ui/notifications/tool-cancelled") {
+          text("status", "Cancelled");
+          text("summary", (message.params && message.params.reason) || "The route was cancelled.");
+        }
+      });
+
+      if ("ResizeObserver" in window) {
+        new ResizeObserver(sendSize).observe(document.documentElement);
+      }
+      post({
+        jsonrpc: "2.0",
+        id: "cascadeflow-init",
+        method: "ui/initialize",
+        params: {
+          appInfo: { name: "cascadeflow route", version: "1.0.0" },
+          appCapabilities: {},
+          protocolVersion: "2026-01-26"
+        }
+      });
+    })();
+  </script>
+</body>
+</html>
+"""
+
+__all__ = ["ROUTING_APP_HTML", "ROUTING_APP_MIME_TYPE", "ROUTING_APP_URI"]

--- a/docs/guides/mcp_integration.md
+++ b/docs/guides/mcp_integration.md
@@ -41,7 +41,11 @@ async def resolve_knowledge(key: str, version: str | None):
         cache_ttl="1h",
     )
 
-mcp = create_mcp_server(agent, knowledge_resolver=resolve_knowledge)
+mcp = create_mcp_server(
+    agent,
+    knowledge_resolver=resolve_knowledge,
+    include_ui=True,  # Optional portable routing/savings panel
+)
 
 # Local desktop transport:
 mcp.run(transport="stdio")
@@ -78,10 +82,32 @@ host. Do not pass provider API keys as MCP tool arguments.
 
 ## MCP Apps / interactive UI
 
-An interactive routing panel is a useful second layer, not part of the routing
-critical path. The standard [MCP Apps extension](https://modelcontextprotocol.io/extensions/apps/overview)
-can render a sandboxed `ui://` resource for model choice, knowledge-version display,
-and savings/latency traces. Keep `cascadeflow_run` fully usable without that UI so
-tool behavior remains portable across hosts. If a host needs product-specific UI
-metadata, add a thin host adapter around the same tool and server-side logic rather
-than forking cascadeflow's routing implementation.
+Set `include_ui=True` to register a self-contained routing panel through the standard
+[MCP Apps extension](https://modelcontextprotocol.io/docs/extensions/apps). The tool
+declares `_meta.ui.resourceUri`, plus ChatGPT's compatibility alias, and serves a
+versioned `ui://` resource using `text/html;profile=mcp-app`. It shows the selected
+model, route, knowledge identity, cost, savings, and latency in a sandboxed view.
+
+The panel is progressive enhancement: `cascadeflow_run` remains fully usable in
+clients that do not render MCP Apps, and the default `include_ui=False` keeps the
+server tool-only. The HTML has no external scripts or network requests. Hosts fetch
+and cache the UI resource separately; it is not appended to model context or to each
+provider query. Tool results remain compact structured data, while private knowledge
+continues to stay behind the server-side resolver.
+
+The UI itself does not remove the host-model turn. In ChatGPT or Claude, the host
+still selects and invokes `cascadeflow_run`, then cascadeflow pays for its own routed
+provider calls. On subscription desktop products that host turn is normally part of
+the product plan. For API-based hosts, include the orchestration model's tokens in
+the end-to-end cost comparison; use a small host model or direct application
+integration when that extra turn would erase the cascade savings.
+
+Run the deterministic transport benchmark with the MCP extra installed:
+
+```bash
+python scripts/benchmark-mcp-app.py
+```
+
+It verifies that enabling the panel changes neither the model-visible tool schema
+nor the provider query/result. The only additions are small host-only `_meta` and a
+separately fetched, cacheable `ui://` resource.

--- a/scripts/benchmark-mcp-app.py
+++ b/scripts/benchmark-mcp-app.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Measure MCP Apps transport overhead without making provider calls."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from cascadeflow.integrations.mcp import create_mcp_server
+from cascadeflow.integrations.mcp_app import ROUTING_APP_URI
+
+
+@dataclass
+class _Result:
+    content: str = "answer"
+    model_used: str = "draft"
+    cascaded: bool = False
+    draft_accepted: bool = True
+    routing_strategy: str = "cascade"
+    total_cost: float = 0.001
+    cost_saved: float = 0.009
+    latency_ms: float = 12.0
+    metadata: dict[str, Any] = field(default_factory=lambda: {"knowledge": {"identity": "docs:v2"}})
+
+
+class _Agent:
+    async def run(self, query: str, **kwargs: Any) -> _Result:
+        return _Result()
+
+
+def _json_bytes(value: Any) -> int:
+    return len(json.dumps(value, sort_keys=True, separators=(",", ":")).encode())
+
+
+async def main() -> None:
+    tool_only = create_mcp_server(_Agent())
+    with_ui = create_mcp_server(_Agent(), include_ui=True)
+
+    tool_only_schema = (await tool_only.list_tools())[0].model_dump(
+        by_alias=True, exclude_none=True
+    )
+    ui_schema = (await with_ui.list_tools())[0].model_dump(by_alias=True, exclude_none=True)
+    model_visible_tool_only = {
+        key: value for key, value in tool_only_schema.items() if key != "_meta"
+    }
+    model_visible_ui = {key: value for key, value in ui_schema.items() if key != "_meta"}
+    if model_visible_tool_only != model_visible_ui:
+        raise RuntimeError("UI changed the model-visible MCP tool schema")
+
+    _, tool_only_result = await tool_only.call_tool("cascadeflow_run", {"query": "hello"})
+    _, ui_result = await with_ui.call_tool("cascadeflow_run", {"query": "hello"})
+    if tool_only_result != ui_result:
+        raise RuntimeError("UI changed the provider-facing tool result")
+
+    app = (await with_ui.read_resource(ROUTING_APP_URI))[0]
+    metadata_bytes = _json_bytes(ui_schema) - _json_bytes(tool_only_schema)
+    app_bytes = len(app.content.encode())
+
+    print("cascadeflow MCP Apps overhead")
+    print("  model-visible schema delta:  0 bytes")
+    print("  provider query/result delta: 0 bytes")
+    print(f"  host-only tool metadata:     {metadata_bytes} bytes")
+    print(f"  cacheable ui:// resource:    {app_bytes} bytes")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -15,10 +15,22 @@ class FakeFastMCP:
         self.name = name
         self.kwargs = kwargs
         self.tools: dict[str, Any] = {}
+        self.tool_metadata: dict[str, dict[str, Any]] = {}
+        self.resources: dict[str, Any] = {}
+        self.resource_metadata: dict[str, dict[str, Any]] = {}
 
     def tool(self, **kwargs: Any):
         def decorate(function):
             self.tools[function.__name__] = function
+            self.tool_metadata[function.__name__] = kwargs
+            return function
+
+        return decorate
+
+    def resource(self, uri: str, **kwargs: Any):
+        def decorate(function):
+            self.resources[uri] = function
+            self.resource_metadata[uri] = kwargs
             return function
 
         return decorate
@@ -83,21 +95,54 @@ async def test_mcp_tool_requires_resolver_and_bounds_conversation_handoff() -> N
         await tool("query", conversation_context="too long")
 
 
+def test_mcp_app_is_opt_in_and_uses_portable_ui_metadata() -> None:
+    from cascadeflow.integrations.mcp_app import ROUTING_APP_MIME_TYPE, ROUTING_APP_URI
+
+    with patch("cascadeflow.integrations.mcp._load_fastmcp", return_value=FakeFastMCP):
+        tool_only = create_mcp_server(FakeAgent())
+        with_ui = create_mcp_server(FakeAgent(), include_ui=True)
+
+    assert tool_only.resources == {}
+    assert tool_only.tool_metadata["cascadeflow_run"]["meta"] is None
+    assert with_ui.tool_metadata["cascadeflow_run"]["meta"] == {
+        "ui": {"resourceUri": ROUTING_APP_URI},
+        "openai/outputTemplate": ROUTING_APP_URI,
+    }
+    assert with_ui.resource_metadata[ROUTING_APP_URI]["mime_type"] == ROUTING_APP_MIME_TYPE
+    html = with_ui.resources[ROUTING_APP_URI]()
+    assert "ui/initialize" in html
+    assert "ui/notifications/tool-result" in html
+    assert "http://" not in html
+    assert "https://" not in html
+
+
 @pytest.mark.asyncio
 async def test_mcp_sdk_discovers_and_calls_cascadeflow_tool() -> None:
     pytest.importorskip("mcp")
 
-    server = create_mcp_server(FakeAgent())
-    tools = await server.list_tools()
+    from cascadeflow.integrations.mcp_app import ROUTING_APP_MIME_TYPE, ROUTING_APP_URI
+    from mcp.shared.memory import create_connected_server_and_client_session
 
-    tool = next(item for item in tools if item.name == "cascadeflow_run")
-    assert tool.title == "Run cascadeflow"
-    assert tool.outputSchema["type"] == "object"
-    assert tool.annotations.readOnlyHint is True
-    assert tool.annotations.destructiveHint is False
-    assert tool.annotations.openWorldHint is True
+    server = create_mcp_server(FakeAgent(), include_ui=True)
+    async with create_connected_server_and_client_session(server) as client:
+        tools = (await client.list_tools()).tools
+        tool = next(item for item in tools if item.name == "cascadeflow_run")
+        assert tool.title == "Run cascadeflow"
+        assert tool.outputSchema["type"] == "object"
+        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.destructiveHint is False
+        assert tool.annotations.openWorldHint is True
+        assert tool.meta["ui"]["resourceUri"] == ROUTING_APP_URI
 
-    content, structured = await server.call_tool("cascadeflow_run", {"query": "current question"})
-    assert content[0].type == "text"
-    assert structured["content"] == "answer"
-    assert structured["model_used"] == "draft"
+        resources = (await client.list_resources()).resources
+        resource = next(item for item in resources if str(item.uri) == ROUTING_APP_URI)
+        assert resource.mimeType == ROUTING_APP_MIME_TYPE
+        contents = (await client.read_resource(ROUTING_APP_URI)).contents
+        assert contents[0].mimeType == ROUTING_APP_MIME_TYPE
+        assert contents[0].meta["ui"]["csp"]["connectDomains"] == []
+        assert "ui/notifications/initialized" in contents[0].text
+
+        result = await client.call_tool("cascadeflow_run", {"query": "current question"})
+        assert result.content[0].type == "text"
+        assert result.structuredContent["content"] == "answer"
+        assert result.structuredContent["model_used"] == "draft"


### PR DESCRIPTION
## Summary\n- add an opt-in, self-contained MCP Apps routing and savings panel\n- use portable ui.resourceUri metadata plus the ChatGPT compatibility alias\n- keep the existing tool-only default and server-side knowledge boundary\n- add real MCP client/server protocol coverage and a deterministic overhead benchmark\n\n## Economics\n- model-visible schema delta: 0 bytes\n- provider query/result delta: 0 bytes\n- host-only tool metadata: 121 bytes\n- cacheable UI resource: 7,104 bytes\n- the host-model tool-selection turn remains and must be counted for API-based hosts\n\n## Validation\n- Python 3.11 with mcp>=1.27,<2: 4 passed\n- Python 3.9 without optional MCP SDK: 3 passed, 1 skipped\n- Black and Ruff: passed\n- embedded JavaScript syntax check: passed\n