### PR TITLE
Add runnable MCP server launcher

### DIFF
--- a/cascadeflow/integrations/mcp.py
+++ b/cascadeflow/integrations/mcp.py
@@ -49,6 +49,9 @@ def create_mcp_server(
     name: str = "cascadeflow",
     max_context_chars: int = 12_000,
     include_ui: bool = False,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    streamable_http_path: str = "/mcp",
 ) -> Any:
     """Create a tool-first MCP server backed by a configured ``CascadeAgent``.
 
@@ -58,6 +61,12 @@ def create_mcp_server(
     """
     if max_context_chars <= 0:
         raise ValueError("max_context_chars must be positive")
+    if not host.strip():
+        raise ValueError("host must be non-empty")
+    if not 1 <= port <= 65_535:
+        raise ValueError("port must be between 1 and 65535")
+    if not streamable_http_path.startswith("/"):
+        raise ValueError("streamable_http_path must start with '/'")
 
     FastMCP = _load_fastmcp()
     server = FastMCP(
@@ -70,6 +79,9 @@ def create_mcp_server(
         ),
         stateless_http=True,
         json_response=True,
+        host=host,
+        port=port,
+        streamable_http_path=streamable_http_path,
     )
 
     tool_meta = None

--- a/cascadeflow/mcp_server.py
+++ b/cascadeflow/mcp_server.py
@@ -1,0 +1,108 @@
+"""CLI entrypoint for serving a configured cascadeflow agent over MCP."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from typing import Any
+
+
+def _is_local_host(host: str) -> bool:
+    return host.strip().lower() in {"127.0.0.1", "localhost", "::1"}
+
+
+def _load_callable(spec: str) -> Any:
+    module_name, separator, attribute = spec.partition(":")
+    if not separator or not module_name or not attribute:
+        raise SystemExit("--knowledge-resolver must use module.path:callable format")
+    try:
+        module = importlib.import_module(module_name)
+        value = getattr(module, attribute)
+    except (ImportError, AttributeError) as exc:
+        raise SystemExit(f"Failed to load --knowledge-resolver {spec!r}: {exc}") from exc
+    if not callable(value):
+        raise SystemExit(f"--knowledge-resolver {spec!r} is not callable")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Serve cascadeflow to ChatGPT, Claude, and other MCP clients"
+    )
+    parser.add_argument("--version", action="store_true", help="Print cascadeflow version and exit")
+    parser.add_argument("--config", help="Cascadeflow YAML or JSON model configuration")
+    parser.add_argument(
+        "--preset",
+        default="balanced",
+        choices=(
+            "balanced",
+            "cost_optimized",
+            "speed_optimized",
+            "quality_optimized",
+            "development",
+        ),
+        help="Auto-detected provider preset when --config is omitted",
+    )
+    parser.add_argument(
+        "--knowledge-resolver",
+        metavar="MODULE:CALLABLE",
+        help="Optional server-side knowledge resolver import",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "streamable-http"),
+        default="stdio",
+        help="stdio for Claude Desktop; streamable-http for remote hosts",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="HTTP bind host")
+    parser.add_argument("--port", type=int, default=8000, help="HTTP bind port")
+    parser.add_argument("--path", default="/mcp", help="Streamable HTTP endpoint path")
+    parser.add_argument("--no-ui", action="store_true", help="Disable the MCP Apps routing panel")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose cascadeflow logging")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+
+    if args.version:
+        from cascadeflow import __version__
+
+        print(__version__)
+        return
+
+    if args.config:
+        from cascadeflow.config_loader import load_agent
+
+        agent = load_agent(args.config, verbose=args.verbose)
+    else:
+        from cascadeflow.utils.presets import auto_agent
+
+        agent = auto_agent(args.preset, verbose=args.verbose, enable_cascade=True)
+
+    resolver = _load_callable(args.knowledge_resolver) if args.knowledge_resolver else None
+
+    from cascadeflow.integrations.mcp import create_mcp_server
+
+    server = create_mcp_server(
+        agent,
+        knowledge_resolver=resolver,
+        include_ui=not args.no_ui,
+        host=args.host,
+        port=args.port,
+        streamable_http_path=args.path,
+    )
+
+    if args.transport == "streamable-http" and not _is_local_host(args.host):
+        print(
+            "WARNING: cascadeflow-mcp does not add authentication or TLS. "
+            "Use a protected HTTPS reverse proxy with OAuth for production.",
+            file=sys.stderr,
+        )
+
+    server.run(transport=args.transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/guides/mcp_integration.md
+++ b/docs/guides/mcp_integration.md
@@ -65,6 +65,55 @@ The `cascadeflow_run` tool accepts:
 The tool returns the answer plus a compact model, routing, cost, latency, and
 knowledge-version trace. It never returns the private knowledge content.
 
+## Runnable launcher
+
+Install the MCP and provider extras, then point the launcher at the same cascadeflow
+configuration used by your application:
+
+```bash
+pip install "cascadeflow[mcp,providers]"
+
+# Claude Desktop and other local MCP clients
+cascadeflow-mcp --config /absolute/path/cascadeflow.yaml
+
+# Local Streamable HTTP endpoint at http://127.0.0.1:8000/mcp
+cascadeflow-mcp \
+  --config /absolute/path/cascadeflow.yaml \
+  --transport streamable-http
+```
+
+The launcher enables the MCP Apps panel by default; pass `--no-ui` for a tool-only
+server. When no config is supplied it auto-detects provider keys and uses the
+`balanced` preset. For private knowledge, expose your application resolver as a
+Python callable and load it without sending knowledge through the client:
+
+```bash
+cascadeflow-mcp \
+  --config /absolute/path/cascadeflow.yaml \
+  --knowledge-resolver my_app.knowledge:resolve
+```
+
+The callable receives `(knowledge_key, knowledge_version)` and returns a string or
+`KnowledgeSnapshot`. It may be synchronous or asynchronous.
+
+Claude Desktop can launch the stdio transport directly:
+
+```json
+{
+  "mcpServers": {
+    "cascadeflow": {
+      "command": "cascadeflow-mcp",
+      "args": ["--config", "/absolute/path/cascadeflow.yaml"]
+    }
+  }
+}
+```
+
+For ChatGPT, run Streamable HTTP locally through the supported secure development
+tunnel, or deploy it behind a stable HTTPS endpoint. The launcher does not add TLS,
+OAuth, tenant authorization, or rate limiting; those belong at the production
+gateway. It prints a warning when HTTP binds to a non-local address.
+
 ## Host choices
 
 - **ChatGPT:** deploy a public HTTPS Streamable HTTP endpoint (normally `/mcp`) and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
 
 [project.scripts]
 cascadeflow-gateway = "cascadeflow.server:main"
+cascadeflow-mcp = "cascadeflow.mcp_server:main"
 
 [project.optional-dependencies]
 # Individual providers (API-based - require API keys)

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -116,6 +116,24 @@ def test_mcp_app_is_opt_in_and_uses_portable_ui_metadata() -> None:
     assert "https://" not in html
 
 
+def test_mcp_server_validates_and_forwards_http_settings() -> None:
+    with patch("cascadeflow.integrations.mcp._load_fastmcp", return_value=FakeFastMCP):
+        server = create_mcp_server(
+            FakeAgent(), host="0.0.0.0", port=9000, streamable_http_path="/cascade"
+        )
+
+    assert server.kwargs["host"] == "0.0.0.0"
+    assert server.kwargs["port"] == 9000
+    assert server.kwargs["streamable_http_path"] == "/cascade"
+
+    with pytest.raises(ValueError, match="host must be non-empty"):
+        create_mcp_server(FakeAgent(), host=" ")
+    with pytest.raises(ValueError, match="port must be between"):
+        create_mcp_server(FakeAgent(), port=0)
+    with pytest.raises(ValueError, match="must start with"):
+        create_mcp_server(FakeAgent(), streamable_http_path="mcp")
+
+
 @pytest.mark.asyncio
 async def test_mcp_sdk_discovers_and_calls_cascadeflow_tool() -> None:
     pytest.importorskip("mcp")

--- a/tests/test_mcp_server_cli.py
+++ b/tests/test_mcp_server_cli.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cascadeflow.mcp_server import _is_local_host, _load_callable, main
+
+
+def test_load_callable_and_local_host_validation() -> None:
+    assert _load_callable("math:sqrt")(9) == 3
+    assert _is_local_host("127.0.0.1") is True
+    assert _is_local_host("::1") is True
+    assert _is_local_host("0.0.0.0") is False
+
+    with pytest.raises(SystemExit, match="module.path:callable"):
+        _load_callable("invalid")
+    with pytest.raises(SystemExit, match="not callable"):
+        _load_callable("math:pi")
+
+
+def test_mcp_cli_loads_config_and_runs_stdio_without_stdout(capsys) -> None:
+    agent = object()
+    resolver = Mock()
+    server = Mock()
+    argv = [
+        "cascadeflow-mcp",
+        "--config",
+        "cascadeflow.yaml",
+        "--knowledge-resolver",
+        "app.knowledge:resolve",
+    ]
+
+    with (
+        patch.object(sys, "argv", argv),
+        patch("cascadeflow.config_loader.load_agent", return_value=agent) as load_agent,
+        patch("cascadeflow.mcp_server._load_callable", return_value=resolver),
+        patch("cascadeflow.integrations.mcp.create_mcp_server", return_value=server) as create,
+    ):
+        main()
+
+    load_agent.assert_called_once_with("cascadeflow.yaml", verbose=False)
+    create.assert_called_once_with(
+        agent,
+        knowledge_resolver=resolver,
+        include_ui=True,
+        host="127.0.0.1",
+        port=8000,
+        streamable_http_path="/mcp",
+    )
+    server.run.assert_called_once_with(transport="stdio")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_mcp_cli_loads_preset_and_warns_for_public_http(capsys) -> None:
+    agent = object()
+    server = Mock()
+    argv = [
+        "cascadeflow-mcp",
+        "--preset",
+        "cost_optimized",
+        "--transport",
+        "streamable-http",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "9000",
+        "--path",
+        "/cascade",
+        "--no-ui",
+    ]
+
+    with (
+        patch.object(sys, "argv", argv),
+        patch("cascadeflow.utils.presets.auto_agent", return_value=agent) as auto_agent,
+        patch("cascadeflow.integrations.mcp.create_mcp_server", return_value=server) as create,
+    ):
+        main()
+
+    auto_agent.assert_called_once_with("cost_optimized", verbose=False, enable_cascade=True)
+    create.assert_called_once_with(
+        agent,
+        knowledge_resolver=None,
+        include_ui=False,
+        host="0.0.0.0",
+        port=9000,
+        streamable_http_path="/cascade",
+    )
+    server.run.assert_called_once_with(transport="streamable-http")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "does not add authentication or TLS" in captured.err


### PR DESCRIPTION
## Summary
- add a packaged `cascadeflow-mcp` launcher for Claude Desktop stdio and remote Streamable HTTP
- support cascadeflow config or provider presets plus server-side knowledge resolvers
- enable the portable MCP Apps routing panel by default with an opt-out
- expose bind host, port, and path while warning on unauthenticated public HTTP
- document Claude Desktop and ChatGPT setup

## Validation
- `python3 -m pytest -q` — 1328 passed, 93 skipped
- Python 3.11 with declared `mcp>=1.27,<2` — 8 passed, including real in-memory MCP client/server exchange
- Ruff and Black checks passed
- wheel build passed and contains the launcher entry point and MCP modules

## Security and cost
- stdio writes no launcher output to stdout
- the knowledge resolver stays server-side
- the UI is a cacheable host resource and does not change provider request/result payloads
- production HTTP still requires an HTTPS/OAuth gateway