### PR TITLE
fix(pricing): resolve model prices by longest prefix, not first match

### DIFF
--- a/cascadeflow/integrations/litellm.py
+++ b/cascadeflow/integrations/litellm.py
@@ -41,6 +41,8 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
+from cascadeflow.pricing.matching import longest_prefix_match
+
 logger = logging.getLogger(__name__)
 
 # Try to import LiteLLM (optional dependency)
@@ -295,11 +297,12 @@ class LiteLLMCostProvider:
             "claude-haiku-4.5": {"input": 1.0, "output": 5.0},
             "claude-3-5-haiku": {"input": 1.0, "output": 5.0},
         }
-        for model_prefix, rates in override_pricing.items():
-            if model.startswith(model_prefix):
-                input_cost = (input_tokens / 1_000_000) * rates["input"]
-                output_cost = (output_tokens / 1_000_000) * rates["output"]
-                return input_cost + output_cost
+        override_prefix = longest_prefix_match(model, override_pricing)
+        if override_prefix is not None:
+            rates = override_pricing[override_prefix]
+            input_cost = (input_tokens / 1_000_000) * rates["input"]
+            output_cost = (output_tokens / 1_000_000) * rates["output"]
+            return input_cost + output_cost
 
         if not LITELLM_AVAILABLE:
             if self.fallback_enabled:
@@ -468,13 +471,14 @@ class LiteLLMCostProvider:
             "default": {"input": 1.0, "output": 2.0},
         }
 
-        # Get pricing by exact match first, then prefix match, then default
+        # Get pricing by exact match first, then longest-prefix match, then default.
+        # Longest wins so "gpt-4o-mini-*" resolves to gpt-4o-mini, not gpt-4.
         pricing = rough_pricing.get(model)
         if pricing is None:
-            for model_prefix, prefix_pricing in rough_pricing.items():
-                if model_prefix != "default" and model.startswith(model_prefix):
-                    pricing = prefix_pricing
-                    break
+            families = [key for key in rough_pricing if key != "default"]
+            model_prefix = longest_prefix_match(model, families)
+            if model_prefix is not None:
+                pricing = rough_pricing[model_prefix]
         if pricing is None:
             pricing = rough_pricing["default"]
 

--- a/cascadeflow/pricing/__init__.py
+++ b/cascadeflow/pricing/__init__.py
@@ -1,3 +1,4 @@
+from .matching import longest_prefix_match
 from .pricebook import ModelPrice, PriceBook, PricingResolver
 
-__all__ = ["ModelPrice", "PriceBook", "PricingResolver"]
+__all__ = ["ModelPrice", "PriceBook", "PricingResolver", "longest_prefix_match"]

--- a/cascadeflow/pricing/matching.py
+++ b/cascadeflow/pricing/matching.py
@@ -1,0 +1,40 @@
+"""Prefix matching helpers for model pricing tables.
+
+Pricing tables are keyed by model family (``gpt-4o``) but callers pass concrete,
+often date-pinned model ids (``gpt-4o-2024-08-06``). Resolving those ids by
+scanning the table and taking the first prefix hit makes the result depend on
+dict insertion order, which silently prices ``gpt-4o-mini`` as ``gpt-4o``.
+
+Matching the *longest* key instead makes resolution order-independent: a more
+specific family always wins over the shorter family it extends.
+
+Kept free of cascadeflow imports so provider and telemetry modules can use it
+without creating import cycles.
+"""
+
+from collections.abc import Iterable
+from typing import Optional
+
+__all__ = ["longest_prefix_match"]
+
+
+def longest_prefix_match(name: str, candidates: Iterable[str]) -> Optional[str]:
+    """Return the longest candidate that is a prefix of ``name``.
+
+    Args:
+        name: Concrete model id, e.g. ``"gpt-4o-mini-2024-07-18"``.
+        candidates: Pricing table keys, e.g. ``{"gpt-4o", "gpt-4o-mini"}``.
+
+    Returns:
+        The matching key, or ``None`` when no candidate is a prefix of ``name``.
+
+    Example:
+        >>> longest_prefix_match("gpt-4o-mini-2024-07-18", ["gpt-4o", "gpt-4o-mini"])
+        'gpt-4o-mini'
+        >>> longest_prefix_match("claude-3-opus", ["gpt-4o"]) is None
+        True
+    """
+    matches = [key for key in candidates if name.startswith(key)]
+    if not matches:
+        return None
+    return max(matches, key=len)

--- a/cascadeflow/pricing/pricebook.py
+++ b/cascadeflow/pricing/pricebook.py
@@ -9,6 +9,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from cascadeflow.pricing.matching import longest_prefix_match
 from cascadeflow.schema.usage import Usage
 
 logger = logging.getLogger(__name__)
@@ -57,11 +58,10 @@ class PriceBook:
         price = self._prices.get(model)
         if price is not None:
             return price
-        # Prefix match for versioned model names (e.g. gpt-4o-2024-08-06)
-        for name, p in self._prices.items():
-            if model.startswith(name):
-                return p
-        return None
+        # Longest-prefix match for versioned model names (e.g. gpt-4o-2024-08-06).
+        # Longest wins so "gpt-4o-mini-*" resolves to gpt-4o-mini, not gpt-4o.
+        name = longest_prefix_match(model, self._prices)
+        return self._prices[name] if name is not None else None
 
     def update(self, model: str, input_per_1k: float, output_per_1k: float) -> None:
         """Add or update a model's pricing at runtime.

--- a/cascadeflow/providers/openrouter.py
+++ b/cascadeflow/providers/openrouter.py
@@ -49,6 +49,7 @@ from typing import Any, Optional
 
 import httpx
 
+from ..pricing.matching import longest_prefix_match
 from ..schema.exceptions import ProviderError
 from .base import BaseProvider, HttpConfig, ModelResponse, RetryConfig
 
@@ -489,12 +490,12 @@ class OpenRouterProvider(BaseProvider):
         # Try exact match first
         pricing = OPENROUTER_PRICING.get(model_lower)
 
-        # Try prefix matching for versioned models
+        # Try longest-prefix matching for versioned models, so that
+        # "openai/gpt-4o-mini-2024-07-18" resolves to gpt-4o-mini, not gpt-4o.
         if not pricing:
-            for key, value in OPENROUTER_PRICING.items():
-                if model_lower.startswith(key):
-                    pricing = value
-                    break
+            key = longest_prefix_match(model_lower, OPENROUTER_PRICING)
+            if key is not None:
+                pricing = OPENROUTER_PRICING[key]
 
         # Fallback to reasonable default (gpt-4o-mini equivalent)
         if not pricing:

--- a/cascadeflow/telemetry/cost_calculator.py
+++ b/cascadeflow/telemetry/cost_calculator.py
@@ -42,6 +42,8 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import Any, Optional
 
+from cascadeflow.pricing.matching import longest_prefix_match
+
 logger = logging.getLogger(__name__)
 
 
@@ -895,13 +897,8 @@ class CostCalculator:
                 "gpt-4": {"input": 0.030, "output": 0.060},
                 "gpt-3.5-turbo": {"input": 0.0005, "output": 0.0015},
             }
-            rates = None
-            for prefix, rate in pricing.items():
-                if name.startswith(prefix):
-                    rates = rate
-                    break
-            if not rates:
-                rates = {"input": 0.030, "output": 0.060}
+            prefix = longest_prefix_match(name, pricing)
+            rates = pricing[prefix] if prefix is not None else {"input": 0.030, "output": 0.060}
             if input_tokens or output_tokens:
                 return (input_tokens / 1000) * rates["input"] + (output_tokens / 1000) * rates[
                     "output"
@@ -924,13 +921,8 @@ class CostCalculator:
                 "claude-3-sonnet": 15.0,
                 "claude-3-haiku": 0.25,
             }
-            blended = None
-            for prefix, rate in rates.items():
-                if name.startswith(prefix):
-                    blended = rate
-                    break
-            if blended is None:
-                blended = 15.0
+            prefix = longest_prefix_match(name, rates)
+            blended = rates[prefix] if prefix is not None else 15.0
             return (total_tokens / 1_000_000) * blended
 
         return None

--- a/tests/test_pricing_prefix_matching.py
+++ b/tests/test_pricing_prefix_matching.py
@@ -1,0 +1,202 @@
+"""Tests for longest-prefix resolution of model pricing.
+
+Pricing tables are keyed by model family but callers pass date-pinned model ids.
+Resolving those by first prefix hit made the result depend on dict insertion
+order, pricing ``gpt-4o-mini-2024-07-18`` as ``gpt-4o`` (and, in the LiteLLM
+fallback table, as ``gpt-4``). Each table below is checked against the family it
+should actually resolve to.
+"""
+
+import pytest
+
+from cascadeflow.integrations.litellm import LiteLLMCostProvider
+from cascadeflow.pricing import PriceBook, PricingResolver, longest_prefix_match
+from cascadeflow.providers.openrouter import OpenRouterProvider
+from cascadeflow.schema.config import ModelConfig
+from cascadeflow.schema.usage import Usage
+from cascadeflow.telemetry.cost_calculator import CostCalculator
+
+ONE_MILLION = 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# helper
+# ---------------------------------------------------------------------------
+
+
+def test_longest_prefix_match_prefers_the_more_specific_family():
+    candidates = ["gpt-4", "gpt-4o", "gpt-4o-mini"]
+
+    assert longest_prefix_match("gpt-4o-mini-2024-07-18", candidates) == "gpt-4o-mini"
+    assert longest_prefix_match("gpt-4o-2024-08-06", candidates) == "gpt-4o"
+    assert longest_prefix_match("gpt-4-0613", candidates) == "gpt-4"
+
+
+def test_longest_prefix_match_is_insertion_order_independent():
+    """Reversing the table must not change which family wins."""
+    forward = ["gpt-4o", "gpt-4o-mini"]
+
+    assert longest_prefix_match("gpt-4o-mini-2024-07-18", forward) == "gpt-4o-mini"
+    assert longest_prefix_match("gpt-4o-mini-2024-07-18", list(reversed(forward))) == "gpt-4o-mini"
+
+
+def test_longest_prefix_match_returns_none_without_a_match():
+    assert longest_prefix_match("claude-3-opus", ["gpt-4o", "gpt-5"]) is None
+
+
+# ---------------------------------------------------------------------------
+# PriceBook (used by CascadeAgent via PricingResolver)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("pinned", "family"),
+    [
+        ("gpt-4o-mini-2024-07-18", "gpt-4o-mini"),
+        ("gpt-4o-2024-08-06", "gpt-4o"),
+        ("o1-mini-2024-09-12", "o1-mini"),
+        ("gpt-5-mini-2025-08-07", "gpt-5-mini"),
+        ("gpt-5-nano-2025-08-07", "gpt-5-nano"),
+    ],
+)
+def test_pricebook_resolves_pinned_ids_to_their_own_family(pinned, family):
+    pricebook = PriceBook()
+
+    assert pricebook.get(pinned) == pricebook.get(family)
+
+
+def test_pricebook_runtime_entry_is_not_shadowed_by_a_shorter_family():
+    """update() must win for its own ids even when a shorter key exists."""
+    pricebook = PriceBook()
+    pricebook.update("gpt-4o-mini-high", input_per_1k=0.002, output_per_1k=0.008)
+
+    price = pricebook.get("gpt-4o-mini-high-2025-01-01")
+
+    assert price.input_per_1k == pytest.approx(0.002)
+    assert price.output_per_1k == pytest.approx(0.008)
+
+
+def test_cascade_savings_are_not_erased_by_drafter_mispricing():
+    """A cheap pinned drafter must stay cheap against a pinned verifier.
+
+    Both ids previously collapsed onto gpt-4o, reporting 0% savings for a
+    cascade that actually saves ~94%.
+    """
+    resolver = PricingResolver()
+    usage = Usage(input_tokens=500, output_tokens=300)
+
+    drafter_cost = resolver.resolve_cost(model="gpt-4o-mini-2024-07-18", usage=usage)
+    verifier_cost = resolver.resolve_cost(model="gpt-4o-2024-08-06", usage=usage)
+
+    assert drafter_cost == pytest.approx(500 / 1000 * 0.00015 + 300 / 1000 * 0.0006)
+    assert drafter_cost < verifier_cost
+    assert (verifier_cost - drafter_cost) / verifier_cost > 0.9
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM fallback table (active whenever litellm is not installed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("pinned", "family"),
+    [
+        ("gpt-4o-mini-2024-07-18", "gpt-4o-mini"),
+        ("gpt-4o-2024-08-06", "gpt-4o"),
+        ("gpt-4-turbo-2024-04-09", "gpt-4-turbo"),
+    ],
+)
+def test_litellm_fallback_prices_pinned_ids_as_their_own_family(monkeypatch, pinned, family):
+    from cascadeflow.integrations import litellm as litellm_integration
+
+    monkeypatch.setattr(litellm_integration, "LITELLM_AVAILABLE", False)
+    provider = LiteLLMCostProvider()
+
+    pinned_cost = provider.calculate_cost(pinned, ONE_MILLION, ONE_MILLION)
+    family_cost = provider.calculate_cost(family, ONE_MILLION, ONE_MILLION)
+
+    assert pinned_cost == pytest.approx(family_cost)
+
+
+def test_litellm_fallback_keeps_default_for_unknown_models(monkeypatch):
+    from cascadeflow.integrations import litellm as litellm_integration
+
+    monkeypatch.setattr(litellm_integration, "LITELLM_AVAILABLE", False)
+    provider = LiteLLMCostProvider()
+
+    cost = provider.calculate_cost("some-unlisted-model", ONE_MILLION, ONE_MILLION)
+
+    assert cost == pytest.approx(1.0 + 2.0)
+
+
+# ---------------------------------------------------------------------------
+# CostCalculator provider-aware fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_input", "expected_output"),
+    [
+        ("gpt-4o-mini", 0.00015, 0.0006),
+        ("gpt-4o-mini-2024-07-18", 0.00015, 0.0006),
+        ("gpt-5-mini", 0.00025, 0.002),
+        ("gpt-5-nano", 0.00005, 0.0004),
+        ("gpt-4o", 0.0025, 0.010),
+    ],
+)
+def test_cost_calculator_fallback_matches_published_openai_rates(
+    model, expected_input, expected_output
+):
+    config = ModelConfig(name=model, provider="openai", cost=0.0)
+
+    cost = CostCalculator._estimate_fallback_cost(
+        config, tokens=0, input_tokens=ONE_MILLION, output_tokens=ONE_MILLION
+    )
+
+    expected = ONE_MILLION / 1000 * (expected_input + expected_output)
+    assert cost == pytest.approx(expected)
+
+
+def test_cost_calculator_fallback_agrees_with_openai_provider_table():
+    """The telemetry fallback must not disagree with the provider pricebook."""
+    from cascadeflow.providers.openai import _openai_model_pricing
+
+    for model in ("gpt-4o-mini", "gpt-5-mini", "gpt-5-nano", "gpt-4o", "gpt-4-turbo"):
+        config = ModelConfig(name=model, provider="openai", cost=0.0)
+        rates = _openai_model_pricing(model)
+
+        cost = CostCalculator._estimate_fallback_cost(
+            config, tokens=0, input_tokens=ONE_MILLION, output_tokens=ONE_MILLION
+        )
+
+        expected = ONE_MILLION / 1000 * (rates["input"] + rates["output"])
+        assert cost == pytest.approx(expected), model
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("pinned", "family"),
+    [
+        ("openai/gpt-4o-mini-2024-07-18", "openai/gpt-4o-mini"),
+        ("openai/o1-mini-2024-09-12", "openai/o1-mini"),
+    ],
+)
+def test_openrouter_prices_pinned_ids_as_their_own_family(pinned, family):
+    provider = OpenRouterProvider.__new__(OpenRouterProvider)
+
+    pinned_cost = provider._calculate_cost(pinned, ONE_MILLION, ONE_MILLION)
+    family_cost = provider._calculate_cost(family, ONE_MILLION, ONE_MILLION)
+
+    assert pinned_cost == pytest.approx(family_cost)
+
+
+def test_openrouter_keeps_default_for_unknown_models():
+    provider = OpenRouterProvider.__new__(OpenRouterProvider)
+
+    cost = provider._calculate_cost("some/unlisted-model", ONE_MILLION, ONE_MILLION)
+
+    assert cost == pytest.approx(0.15 + 0.6)


### PR DESCRIPTION
## 🎯 Description

Model pricing tables in this repo are keyed by model *family* (`gpt-4o`), but callers pass concrete model ids (`gpt-4o-mini-2024-07-18`). Four lookups resolved the concrete id by scanning the table and returning the **first** prefix hit. Because dicts preserve insertion order, whichever family happened to be declared first won, and a cheap variant got billed at the rate of the more expensive family whose name it extends.

`gpt-4o-mini` starts with `gpt-4o`, so it matched `gpt-4o`. In the LiteLLM fallback table it matched `gpt-4` and picked up GPT-4 rates.

Affected lookups:

| Location | Example input | Resolved as | Overcharge |
|---|---|---|---|
| `PriceBook.get()` | `gpt-4o-mini-2024-07-18` | `gpt-4o` | 16.7x |
| `LiteLLMCostProvider._fallback_cost()` | `gpt-4o-mini-2024-07-18` | `gpt-4` | 120x |
| `CostCalculator._estimate_fallback_cost()` | `gpt-4o-mini` | `gpt-4o` | 16.7x |
| `OpenRouterProvider._calculate_cost()` | `openai/o1-mini-2024-09-12` | `openai/o1` | 5x |

`gpt-5-mini` and `gpt-5-nano` collapse onto `gpt-5` the same way (5x and 25x).

**Why this one stings:** the mispriced models are the small ones, and small models are what a cascade drafts with. `gpt-4o-mini` alone appears in five of the built-in presets as a cheap-tier model. So the error lands on exactly the side of the cascade that is supposed to be cheap, and it inflates the savings figure the library exists to report.

With a `gpt-4o-mini-2024-07-18` drafter against a `gpt-4o-2024-08-06` verifier, both ids collapsed onto `gpt-4o`, so a cascade that really saves 94% reported **0% savings**.

The fix is to match the **longest** key rather than the first, which makes resolution independent of table order. This is not a new convention: `providers/openai.py` and `providers/anthropic.py` already do exactly this (`max(matches, key=len)`), and `integrations/langchain/models.py` sorts longest-first for the same reason. I pulled that logic into one small helper so the remaining four tables stop hand-rolling it.

## 🔗 Related Issues

<!-- No existing issue found for this; happy to open one if you'd prefer it tracked separately. -->

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

New file `tests/test_pricing_prefix_matching.py`, 23 tests. **16 of them fail on `main`** and pass here, covering all four lookups.

The tests also pin down the behaviour that must *not* change:

- unknown models still fall back to their table defaults
- exact matches are unaffected
- `CostCalculator`'s OpenAI fallback is asserted against `_openai_model_pricing`, so the two OpenAI tables can no longer silently drift apart

### Test cases added
- [x] Unit tests

### Full suite
```
1254 passed, 42 skipped, 59 deselected
```
1231 passed before this branch, so no regressions and 23 added.

Also run locally with the versions CI pins:
- `black --check cascadeflow tests examples` (black 25.11.0) clean
- `ruff check cascadeflow tests examples` (ruff 0.15.0) clean
- `bandit -r cascadeflow/ -ll` no medium or high findings
- syntax checked against Python 3.9, the minimum supported version

`mypy cascadeflow --ignore-missing-imports` fails identically on `main` and on this branch in my environment (numpy stub needs a newer `python_version` than `pyproject.toml` sets), so it is untouched by this change.

### How to test

```python
from cascadeflow.pricing import PriceBook

book = PriceBook()
for model in ("gpt-4o-mini-2024-07-18", "gpt-4o-2024-08-06", "o1-mini-2024-09-12"):
    price = book.get(model)
    print(f"{model:24s} in={price.input_per_1k:<9} out={price.output_per_1k}")
```

**Before:**
```
gpt-4o-mini-2024-07-18   in=0.0025    out=0.01
gpt-4o-2024-08-06        in=0.0025    out=0.01
o1-mini-2024-09-12       in=0.015     out=0.06
```

**After:**
```
gpt-4o-mini-2024-07-18   in=0.00015   out=0.0006
gpt-4o-2024-08-06        in=0.0025    out=0.01
o1-mini-2024-09-12       in=0.003     out=0.012
```

## 📋 Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added type hints where appropriate
- [x] I have run `black` to format my code
- [x] I have run `ruff` and fixed all linting issues
- [x] I have run `mypy` for type checking

### Testing
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested error cases and edge conditions
- [x] I have tested with the minimum supported Python version (3.9)

### Documentation
- [x] I have added docstrings to new functions/classes
- [ ] CHANGELOG.md not updated: it looks like it is only revised at release time, so I left it alone. Happy to add an entry if you'd rather.

### Dependencies
- [x] No new dependencies

### Breaking Changes
- [x] This PR includes NO breaking changes

Costs go **down** for correctly-priced small models, never up. Exact matches, unmatched models, and the Anthropic and LiteLLM override tables are unaffected, since those tables already had their keys ordered longest-first. The change makes that ordering no longer load-bearing.

## 📊 Performance Impact

Negligible. The helper builds a list of matching keys and takes the longest instead of breaking on the first hit, so it scans the whole table rather than stopping early. These tables hold on the order of ten to twenty entries and are consulted once per response.

## 🔐 Security Considerations

- [x] This PR does not introduce security vulnerabilities
- [x] I have not exposed sensitive information

## Notes for the reviewer

One judgement call worth flagging: I added `cascadeflow/pricing/matching.py` rather than repeating `max(matches, key=len)` a fourth, fifth and sixth time. It is deliberately free of cascadeflow imports so `providers/` and `telemetry/` can use it without an import cycle.

I did **not** touch `providers/openai.py`, `providers/anthropic.py` or `integrations/langchain/models.py`. They are already correct, and rewriting working code felt like scope creep for a bug fix. They could adopt the helper in a follow-up if you want the duplication gone.

`providers/groq.py` has the same first-match pattern but no key in its table is a prefix of another, so it is not currently affected. I left it as is and did not want to widen the diff, though it is fragile the next time a model is added.
