### PR TITLE
docs: expand TypeScript coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -308,6 +308,9 @@ jobs:
       - name: Type check TypeScript Examples
         run: pnpm --filter @cascadeflow/core typecheck:examples
 
+      - name: Check TypeScript documentation snippets
+        run: pnpm run docs:check-typescript
+
       - name: Lint n8n Integration
         run: pnpm --filter @cascadeflow/n8n-nodes-cascadeflow lint
 

--- a/docs-site/api-reference/typescript/cascade-agent.mdx
+++ b/docs-site/api-reference/typescript/cascade-agent.mdx
@@ -1,0 +1,128 @@
+---
+title: CascadeAgent
+description: TypeScript CascadeAgent API for model cascading, routing, batch execution, tools, and streaming.
+---
+
+`CascadeAgent` runs the least expensive suitable model first and escalates when validation or routing requires it.
+
+## Constructor
+
+```typescript
+import { CascadeAgent, type AgentConfig } from '@cascadeflow/core';
+
+const config: AgentConfig = {
+  models: [
+    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.00015 },
+    { name: 'gpt-4o', provider: 'openai', cost: 0.0025 },
+  ],
+  quality: {
+    threshold: 0.7,
+    requireMinimumTokens: 3,
+  },
+};
+
+const agent = new CascadeAgent(config);
+```
+
+Models are sorted by cost. A single model produces direct execution, while two or more models enable cascading.
+
+## run()
+
+```typescript
+const result = await agent.run('Explain speculative execution', {
+  maxTokens: 500,
+  temperature: 0.2,
+  systemPrompt: 'Answer for a software engineer.',
+});
+```
+
+The input can be a string or an array of universal `Message` objects.
+
+```typescript
+const result = await agent.run([
+  { role: 'system', content: 'Answer concisely.' },
+  { role: 'user', content: 'What is model cascading?' },
+]);
+```
+
+## RunOptions
+
+| Option | Type | Purpose |
+|---|---|---|
+| `maxTokens` | number | Maximum generated tokens |
+| `temperature` | number | Sampling temperature from 0 to 2 |
+| `systemPrompt` | string | Stable system instruction |
+| `knowledge` | string or `KnowledgeSnapshot` | Request-scoped provider-neutral knowledge |
+| `tools` | `Tool[]` | Available tool definitions |
+| `toolExecutor` | `ToolExecutor` | Tool implementation registry |
+| `maxSteps` | number | Maximum model calls in a tool loop |
+| `extra` | object | Provider-specific options |
+| `forceDirect` | boolean | Skip cascading |
+| `userTier` | string | Apply tier-based filtering |
+| `workflow` | string | Select a workflow profile |
+| `kpiFlags` | object | Add rule-engine KPI context |
+| `tenantId` | string | Apply tenant rules |
+| `channel` | string | Apply channel routing and failover |
+
+## Tools
+
+```typescript
+const result = await agent.run('What is the weather in Zurich?', {
+  tools: [weatherTool.toOpenAIFormat()],
+  toolExecutor: new ToolExecutor([weatherTool]),
+  maxSteps: 5,
+});
+```
+
+See [Tools](/api-reference/typescript/tools) for complete setup.
+
+## Batch Execution
+
+```typescript
+const batch = await agent.runBatch(
+  ['Summarize A', 'Summarize B'],
+  { maxParallel: 2, stopOnError: false },
+  { maxTokens: 200 },
+);
+
+console.log(batch.successCount, batch.failureCount);
+```
+
+## Streaming
+
+```typescript
+import { StreamEventType } from '@cascadeflow/core';
+
+for await (const event of agent.stream('Write a short explanation')) {
+  if (event.type === StreamEventType.CHUNK) {
+    process.stdout.write(event.content);
+  }
+}
+```
+
+See [Streaming](/api-reference/typescript/streaming).
+
+## Inspection
+
+```typescript
+console.log(agent.getModels());
+console.log(agent.getModelCount());
+console.log(agent.getRouterStats());
+
+agent.resetRouterStats();
+```
+
+## Methods
+
+| Method | Returns |
+|---|---|
+| `run(input, options?)` | `Promise<CascadeResult>` |
+| `runBatch(queries, batchConfig?, runOptions?)` | `Promise<BatchResult>` |
+| `runStream(input, options?)` | `AsyncIterable<StreamEvent>` |
+| `runStreaming(query, options?)` | `Promise<CascadeResult>` |
+| `streamEvents(input, options?)` | `AsyncIterable<StreamEvent>` |
+| `stream(input, options?)` | `AsyncIterable<StreamEvent>` |
+| `getModels()` | `ModelConfig[]` |
+| `getModelCount()` | number |
+| `getRouterStats()` | router statistics object |
+| `resetRouterStats()` | void |

--- a/docs-site/api-reference/typescript/configuration.mdx
+++ b/docs-site/api-reference/typescript/configuration.mdx
@@ -1,11 +1,35 @@
 ---
 title: Configuration
-description: TypeScript configuration types — AgentConfig, QualityConfig, CascadeConfig, RunOptions, and presets.
+description: TypeScript configuration types for models, agents, quality validation, cascade behavior, runs, and presets.
 ---
 
 # Configuration
 
 Full reference for `@cascadeflow/core` configuration types.
+
+## ModelConfig
+
+```typescript
+interface ModelConfig {
+  name: string;
+  provider: Provider;
+  cost: number;                         // Configured cost per 1,000 tokens
+  keywords?: string[];
+  domains?: string[];
+  maxTokens?: number;
+  systemPrompt?: string;
+  temperature?: number;
+  apiKey?: string;
+  baseUrl?: string;
+  extra?: Record<string, any>;
+  speedMs?: number;
+  qualityScore?: number;
+  supportsTools?: boolean;
+  toolQuality?: number;
+  qualityThreshold?: number;
+  httpConfig?: HttpConfig;
+}
+```
 
 ## AgentConfig
 
@@ -13,7 +37,7 @@ Passed to `new CascadeAgent(config)`.
 
 ```typescript
 interface AgentConfig {
-  models: ModelConfig[];                    // Required — sorted by cost
+  models: ModelConfig[];                    // Required, sorted by cost
   quality?: QualityConfig;                  // Quality validation
   cascade?: CascadeConfig;                  // Cascade behavior
   toolExecutor?: ToolExecutor;              // Tool execution
@@ -23,9 +47,11 @@ interface AgentConfig {
   tiers?: Record<string, TierRouterConfig>; // User tier definitions
   workflows?: Record<string, WorkflowProfile>; // Workflow profiles
   tenantRules?: Record<string, Record<string, unknown>>; // Per-tenant overrides
-  channelModels?: Record<string, string[]>; // Channel → allowed models
+  channelModels?: Record<string, string[]>; // Channel to allowed models
   channelFailover?: Record<string, string>; // Channel failover map
+  channelStrategies?: Record<string, string>; // Channel routing strategy map
   ruleEngineConfig?: RuleEngineConfig;      // Rule engine config
+  ruleEngine?: RuleEngine;                  // Custom rule engine
 }
 ```
 
@@ -41,11 +67,11 @@ interface QualityConfig {
     hard?: number;
     expert?: number;
   };
-  requireMinimumTokens?: number;       // Min response length (default: 10)
+  requireMinimumTokens?: number;       // Min response length (default: 3)
   requireValidation?: boolean;         // Enable validation (default: true)
   useSemanticValidation?: boolean;     // ML-based validation
   semanticThreshold?: number;          // Semantic similarity threshold
-  enableAdaptive?: boolean;            // Adaptive thresholds (default: false)
+  enableAdaptive?: boolean;            // Adaptive thresholds (default: true)
 }
 ```
 
@@ -56,10 +82,11 @@ interface CascadeConfig {
   quality?: QualityConfig;             // Quality settings
   maxBudget?: number;                  // Max budget per query (USD)
   trackCosts?: boolean;                // Cost tracking (default: true)
-  maxRetries?: number;                 // Max retries per model (default: 0)
-  timeout?: number;                    // Timeout in seconds (default: 60)
-  routingStrategy?: 'cost' | 'quality' | 'speed'; // Routing strategy
-  useSpeculative?: boolean;            // Speculative execution (default: false)
+  maxRetries?: number;                 // Max retries per model (default: 2)
+  timeout?: number;                    // Timeout in seconds (default: 30)
+  routingStrategy?: 'adaptive' | 'cost_first' | 'quality_first'
+    | 'speed_first' | 'semantic';       // Routing strategy
+  useSpeculative?: boolean;            // Speculative execution (default: true)
   verbose?: boolean;                   // Verbose logging
   trackMetrics?: boolean;              // Performance metrics (default: true)
 }
@@ -74,6 +101,7 @@ interface RunOptions {
   maxTokens?: number;                  // Max tokens to generate
   temperature?: number;                // Temperature (0-2)
   systemPrompt?: string;               // System prompt
+  knowledge?: string | KnowledgeSnapshot; // Request-scoped knowledge
   tools?: Tool[];                      // Available tools
   toolExecutor?: ToolExecutor;         // Tool executor
   maxSteps?: number;                   // Max tool loop steps
@@ -107,7 +135,7 @@ const agent = new CascadeAgent(PRESET_BEST_OVERALL);
 
 | Preset | Description |
 |---|---|
-| `PRESET_BEST_OVERALL` | Claude Haiku + GPT-5 |
+| `PRESET_BEST_OVERALL` | Claude Haiku 4.5 + GPT-4o mini |
 | `PRESET_ULTRA_FAST` | Fastest cascade pair |
 | `PRESET_ULTRA_CHEAP` | Cheapest cascade pair |
 | `PRESET_OPENAI_ONLY` | OpenAI models only |

--- a/docs-site/api-reference/typescript/core.mdx
+++ b/docs-site/api-reference/typescript/core.mdx
@@ -1,9 +1,12 @@
 ---
 title: "@cascadeflow/core"
-description: TypeScript core package with CascadeAgent for model routing, cost tracking, and quality validation.
+description: Entry point for the TypeScript cascade, harness, routing, tool, quality, and telemetry APIs.
 ---
 
-The core TypeScript package for cascadeflow. Provides `CascadeAgent` for speculative model cascading with quality validation.
+`@cascadeflow/core` contains two complementary runtime APIs:
+
+- `CascadeAgent` performs speculative model cascading and quality validation.
+- The harness observes or enforces policy around OpenAI and Anthropic SDK calls.
 
 ## Install
 
@@ -11,65 +14,70 @@ The core TypeScript package for cascadeflow. Provides `CascadeAgent` for specula
 npm install @cascadeflow/core
 ```
 
-## CascadeAgent
+Node.js 18 or newer is required.
+
+## Cascade API
 
 ```typescript
-import { CascadeAgent, ModelConfig } from '@cascadeflow/core';
+import { CascadeAgent } from '@cascadeflow/core';
 
 const agent = new CascadeAgent({
   models: [
-    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.000375 },
-    { name: 'gpt-4o', provider: 'openai', cost: 0.00625 },
+    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.00015 },
+    { name: 'gpt-4o', provider: 'openai', cost: 0.0025 },
   ],
 });
 
-const result = await agent.run('What is TypeScript?');
-console.log(`Model: ${result.modelUsed}`);
-console.log(`Cost: $${result.totalCost}`);
-console.log(`Saved: ${result.savingsPercentage}%`);
+const result = await agent.run('Summarize this document');
+console.log(result.content);
+console.log(result.modelUsed, result.totalCost, result.savingsPercentage);
 ```
 
-## ModelConfig
+See [CascadeAgent](/api-reference/typescript/cascade-agent), [Configuration](/api-reference/typescript/configuration), and [CascadeResult](/api-reference/typescript/result).
+
+## Harness API
 
 ```typescript
-interface ModelConfig {
-  name: string;        // Model name (e.g. 'gpt-4o-mini')
-  provider: string;    // Provider name (e.g. 'openai')
-  cost: number;        // Cost per token (approximate)
-}
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'observe' });
+
+await run({ budget: 0.50 }, async (session) => {
+  await existingAgentWork();
+  console.log(session.summary());
+  console.log(session.trace());
+});
 ```
 
-## CascadeAgentOptions
+See [Harness](/api-reference/typescript/harness).
 
-```typescript
-interface CascadeAgentOptions {
-  models: ModelConfig[];
-  quality?: {
-    threshold?: number;              // Confidence threshold (0-1)
-    requireMinimumTokens?: number;   // Min response length
-    useSemanticValidation?: boolean; // Enable ML validation
-    semanticThreshold?: number;      // Semantic similarity threshold
-  };
-}
-```
+## Main Export Groups
 
-## Result
+| Area | Main exports |
+|---|---|
+| Cascade | `CascadeAgent`, `AgentConfig`, `RunOptions`, `CascadeResult` |
+| Harness | `init`, `run`, `harnessAgent`, `HarnessRunContext` |
+| Streaming | `StreamEventType`, `collectStream`, `collectResult` |
+| Tools | `ToolConfig`, `ToolExecutor`, `ToolCall`, `ToolResult` |
+| Quality | `QualityValidator`, `SemanticQualityChecker`, `ComplexityDetector` |
+| Routing | `PreRouter`, `ToolRouter`, `TierRouter`, `DomainRouter`, `RuleEngine` |
+| Providers | OpenAI, Anthropic, Groq, Together, Ollama, Hugging Face, vLLM, OpenRouter, and Vercel AI adapters |
+| Operations | `BatchProcessor`, `RetryManager`, `ResponseCache`, `RateLimiter` |
+| Telemetry | `CallbackManager`, `MetricsCollector`, `CostCalculator`, `OpenTelemetryExporter` |
 
-```typescript
-interface CascadeResult {
-  content: string;
-  modelUsed: string;
-  totalCost: number;
-  savingsPercentage: number;
-  cascadeDecision: string;
-}
-```
+## Next Steps
 
-## Features
-
-- Speculative execution with quality validation
-- Multi-provider support (OpenAI, Anthropic, Groq, Ollama, vLLM)
-- Streaming responses
-- Tool calling and structured output
-- Cost tracking and analytics
-- Works in Node.js, Browser, and Edge Functions
+<CardGroup cols={2}>
+  <Card title="Build a cascade" icon="layer-group" href="/api-reference/typescript/cascade-agent">
+    Configure models, quality checks, routing, streaming, and batch execution.
+  </Card>
+  <Card title="Add runtime policy" icon="shield" href="/api-reference/typescript/harness">
+    Observe or enforce budgets, tool caps, energy, latency, and compliance.
+  </Card>
+  <Card title="Execute tools" icon="wrench" href="/api-reference/typescript/tools">
+    Define tools and run automatic multi-step tool loops.
+  </Card>
+  <Card title="Check feature parity" icon="table-columns" href="/api-reference/typescript/feature-parity">
+    Compare the current Python and TypeScript surfaces.
+  </Card>
+</CardGroup>

--- a/docs-site/api-reference/typescript/feature-parity.mdx
+++ b/docs-site/api-reference/typescript/feature-parity.mdx
@@ -1,0 +1,67 @@
+---
+title: Python and TypeScript Parity
+sidebarTitle: Feature Parity
+description: Current capability matrix for the Python and TypeScript cascadeflow packages.
+---
+
+Python and TypeScript share the main cascade and harness concepts, but they do not have identical integration and operations surfaces.
+
+## Core Runtime
+
+| Capability | Python | TypeScript |
+|---|---|---|
+| CascadeAgent and speculative routing | Yes | Yes |
+| Observe and enforce harness modes | Yes | Yes |
+| OpenAI and Anthropic instrumentation | Yes | Yes |
+| Budget, tool-call, latency, and energy controls | Yes | Yes |
+| KPI-weighted model selection | Yes | Yes |
+| Streaming | Yes | Yes |
+| Automatic tool loops | Yes | Yes |
+| Batch processing | Yes | Yes |
+| Domain, tier, and rule routing | Yes | Yes |
+| Guardrails and rate limiting | Yes | Yes |
+| Semantic quality validation | Yes | Yes |
+| Provider-neutral knowledge cache | Yes | Yes |
+
+## Harness Differences
+
+| Capability | Python | TypeScript |
+|---|---|---|
+| Compliance profiles | `gdpr`, `hipaa`, `pci`, `strict` | `regulated`, `strict` |
+| Session JSONL save and load | Yes | No |
+| Harness callback manager | Yes | No |
+| Config files | YAML and JSON | JSON |
+| Parameter validation | Strict validation | Basic normalization |
+
+## Integrations
+
+| Integration | Python | TypeScript |
+|---|---|---|
+| LangChain and LangGraph | Yes | Yes |
+| OpenAI Agents SDK | Yes | No |
+| CrewAI | Yes | No |
+| Google ADK | Yes | No |
+| PydanticAI | Yes | No |
+| OpenClaw | Yes | No |
+| Hermes Agent | Yes | No |
+| MCP server and app bridge | Yes | No |
+| Vercel AI SDK | No | Yes |
+| n8n community node | No | Yes |
+| Browser and edge cascade runtime | Limited | Yes |
+
+## Operations
+
+| Capability | Python | TypeScript |
+|---|---|---|
+| Proxy and gateway server | Yes | No |
+| Simulation | Yes | No |
+| Dynamic configuration watcher | Yes | No |
+| Circuit breaker | Yes | No |
+| Anomaly and degradation detection | Yes | No |
+| Retry manager | Provider and resilience layers | Yes |
+| Response cache | Yes | Yes |
+| OpenTelemetry exporter | Yes | Yes |
+
+<Note>
+This matrix describes the current repository implementation. It intentionally does not imply that a similarly named feature has identical configuration or behavior in both languages.
+</Note>

--- a/docs-site/api-reference/typescript/harness.mdx
+++ b/docs-site/api-reference/typescript/harness.mdx
@@ -1,0 +1,136 @@
+---
+title: Harness
+description: TypeScript harness API for observe and enforce modes, scoped runs, policy controls, summaries, and decision traces.
+---
+
+The TypeScript harness instruments OpenAI and Anthropic SDK calls made inside a scoped run. It can record decisions in `observe` mode or apply them in `enforce` mode.
+
+## Initialize
+
+```typescript
+import { init } from '@cascadeflow/core';
+
+const report = init({
+  mode: 'observe',
+  verbose: false,
+});
+
+console.log(report.mode);
+console.log(report.instrumented);
+console.log(report.detectedButNotInstrumented);
+```
+
+Configuration precedence is explicit code, environment variables, `cascadeflow.json` or `cascadeflow.config.json`, and built-in defaults.
+
+## Scoped Run
+
+`run()` takes an optional policy object and a callback. The callback receives the active `HarnessRunContext`.
+
+```typescript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+
+const value = await run({
+  budget: 0.50,
+  maxToolCalls: 8,
+  maxLatencyMs: 5000,
+  maxEnergy: 100,
+  kpiWeights: { quality: 0.6, cost: 0.3, latency: 0.1 },
+  compliance: 'regulated',
+}, async (session) => {
+  const result = await existingAgentWork();
+  console.log(session.summary());
+  return result;
+});
+```
+
+Node.js uses `AsyncLocalStorage` to preserve nested and concurrent run context.
+
+## Run Options
+
+```typescript
+type HarnessRunOptions = {
+  budget?: number;
+  maxToolCalls?: number;
+  maxLatencyMs?: number;
+  maxEnergy?: number;
+  kpiTargets?: Record<string, number>;
+  kpiWeights?: Record<string, number>;
+  compliance?: string;
+};
+```
+
+`kpiWeights` affects built-in model selection. `kpiTargets` is retained as policy metadata but is not currently used by the built-in scoring decision.
+
+## Summary and Trace
+
+```typescript
+await run({ budget: 0.50 }, async (session) => {
+  await existingAgentWork();
+
+  const summary = session.summary();
+  console.log(summary.cost);
+  console.log(summary.stepCount);
+  console.log(summary.budgetRemaining);
+
+  for (const record of session.trace()) {
+    console.log(record.action, record.reason, record.applied);
+  }
+});
+```
+
+See [Decision Traces](/harness/decision-trace) for the complete field mapping.
+
+## Function Policy Metadata
+
+The root package exports the harness function wrapper as `harnessAgent` to avoid a naming conflict with `CascadeAgent`.
+
+```typescript
+import { harnessAgent } from '@cascadeflow/core';
+
+const analyzedAgent = harnessAgent({
+  budget: 0.20,
+  compliance: 'regulated',
+})(async (query: string) => existingAgent(query));
+```
+
+`harnessAgent()` attaches policy metadata. It does not create a scoped run automatically.
+
+## Errors and Reset
+
+```typescript
+import {
+  BudgetExceededError,
+  HarnessStopError,
+  resetHarness,
+  run,
+} from '@cascadeflow/core';
+
+try {
+  await run({ budget: 0 }, async () => existingAgentWork());
+} catch (error) {
+  if (error instanceof BudgetExceededError) {
+    console.error(error.remaining);
+  } else if (error instanceof HarnessStopError) {
+    console.error(error.reason);
+  }
+}
+
+resetHarness();
+```
+
+## Current Instrumentation Scope
+
+| Capability | TypeScript support |
+|---|---|
+| OpenAI SDK | Yes |
+| Anthropic SDK | Yes |
+| Observe and enforce | Yes |
+| Budget, tool-call, latency, and energy controls | Yes |
+| KPI weights | Yes |
+| Compliance profiles | `regulated`, `strict` |
+| Session JSONL save and load | No |
+| Harness callback manager | No |
+
+See [Feature Parity](/api-reference/typescript/feature-parity) before relying on Python examples in a TypeScript application.

--- a/docs-site/api-reference/typescript/langchain.mdx
+++ b/docs-site/api-reference/typescript/langchain.mdx
@@ -39,7 +39,14 @@ const chain = prompt.pipe(cascade).pipe(new StringOutputParser());
 interface CascadeOptions {
   drafter: BaseChatModel;        // Cheap, fast model
   verifier: BaseChatModel;       // Powerful fallback model
-  qualityThreshold?: number;     // 0-1, default 0.4
+  qualityThreshold?: number;     // 0-1, default 0.7
+  enableCostTracking?: boolean;
+  costTrackingProvider?: 'langsmith' | 'cascadeflow';
+  qualityValidator?: (response: unknown) => number | Promise<number>;
+  enablePreRouter?: boolean;
+  preRouter?: PreRouter;
+  cascadeComplexities?: QueryComplexity[];
+  domainPolicies?: Record<string, DomainPolicy>;
 }
 ```
 

--- a/docs-site/api-reference/typescript/overview.mdx
+++ b/docs-site/api-reference/typescript/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: TypeScript API
 sidebarTitle: Overview
-description: TypeScript API reference for cascadeflow — CascadeAgent, Vercel AI middleware, and LangChain integration.
+description: TypeScript API reference for the cascade, harness, tools, integrations, and runtime utilities.
 ---
 
 # TypeScript API Reference
 
-cascadeflow provides three TypeScript packages for different integration patterns.
+cascadeflow provides TypeScript packages for direct cascading, framework integration, semantic validation, and workflow automation.
 
 ## Quick Start
 
@@ -29,9 +29,11 @@ console.log(`Model: ${result.modelUsed}, Cost: $${result.totalCost}`);
 
 | Package | Purpose | Docs |
 |---|---|---|
-| `@cascadeflow/core` | CascadeAgent with speculative execution and cost tracking | [Reference](/api-reference/typescript/core) |
+| `@cascadeflow/core` | CascadeAgent, harness, tools, routing, quality, and telemetry | [Reference](/api-reference/typescript/core) |
 | `@cascadeflow/vercel-ai` | Vercel AI SDK middleware with streaming and tool loops | [Reference](/api-reference/typescript/vercel-ai) |
 | `@cascadeflow/langchain` | LangChain `withCascade()` wrapper and model discovery | [Reference](/api-reference/typescript/langchain) |
+| `@cascadeflow/ml` | Optional local semantic validation with Transformers.js | [Quality and routing](/api-reference/typescript/quality-routing) |
+| `@cascadeflow/n8n-nodes-cascadeflow` | n8n community nodes | [n8n integration](/integrations/n8n) |
 
 ## Install
 
@@ -44,15 +46,20 @@ npm install @cascadeflow/vercel-ai
 
 # LangChain integration
 npm install @cascadeflow/langchain @langchain/core @langchain/openai
+
+# Optional semantic validation
+npm install @cascadeflow/ml @huggingface/transformers
 ```
 
 ## Core Concepts
 
-**Speculative execution** — the cheaper model (drafter) runs first. If its response passes quality validation, cascadeflow returns it without calling the expensive model. If not, the verifier model runs as fallback.
+**Speculative execution**: The cheaper model runs first. If its response passes quality validation, cascadeflow returns it without calling the expensive model. Otherwise the verifier runs as fallback.
 
-**Quality validation** — configurable confidence threshold, minimum token count, and optional semantic validation determine whether a draft is accepted.
+**Quality validation**: Configurable confidence, alignment, response analysis, and optional semantic validation determine whether a draft is accepted.
 
-**Cost tracking** — every response includes `totalCost` and `savingsPercentage` so you can measure optimization impact.
+**Runtime harness**: Observe or enforce budgets, tool-call caps, latency, energy, KPI weights, and compliance around existing OpenAI and Anthropic SDK calls.
+
+**Cost tracking**: Every cascade response includes `totalCost`, with optional savings and cost breakdown fields.
 
 ## Integration Patterns
 
@@ -94,6 +101,28 @@ const cascade = withCascade({
 const chain = prompt.pipe(cascade).pipe(new StringOutputParser());
 ```
 
+### Harness
+
+Use the harness around an existing SDK-based agent:
+
+```typescript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'observe' });
+
+await run({ budget: 0.50 }, async (session) => {
+  await existingAgentWork();
+  console.log(session.summary());
+});
+```
+
 ## Runtime Support
 
-All packages work in Node.js, Browser, and Edge Functions (Vercel Edge, Cloudflare Workers).
+| Surface | Node.js | Browser | Edge runtime |
+|---|---|---|---|
+| `CascadeAgent` | Yes | Yes | Yes, with compatible providers |
+| Harness SDK instrumentation | Yes | No | No |
+| Vercel AI integration | Yes | Client hooks only | Yes |
+| LangChain integration | Yes | Depends on LangChain provider | Depends on provider |
+
+See [Feature Parity](/api-reference/typescript/feature-parity) for differences from Python.

--- a/docs-site/api-reference/typescript/providers.mdx
+++ b/docs-site/api-reference/typescript/providers.mdx
@@ -1,0 +1,63 @@
+---
+title: Providers
+description: Built-in TypeScript providers, environment variables, custom endpoints, and provider registry APIs.
+---
+
+## Built-in Providers
+
+| Provider | `provider` value | Environment variable |
+|---|---|---|
+| OpenAI | `openai` | `OPENAI_API_KEY` |
+| Anthropic | `anthropic` | `ANTHROPIC_API_KEY` |
+| Groq | `groq` | `GROQ_API_KEY` |
+| Together AI | `together` | `TOGETHER_API_KEY` |
+| Hugging Face | `huggingface` | `HUGGINGFACE_API_KEY` |
+| OpenRouter | `openrouter` | `OPENROUTER_API_KEY` |
+| Ollama | `ollama` | Not required |
+| vLLM | `vllm` | Depends on deployment |
+
+Vercel AI adapters add Azure, Bedrock, Cohere, DeepSeek, Fireworks, Google, Mistral, Perplexity, Vertex, xAI, and other provider identifiers.
+
+## Model Configuration
+
+```typescript
+const model = {
+  name: 'gpt-4o-mini',
+  provider: 'openai' as const,
+  cost: 0.00015,
+  apiKey: process.env.OPENAI_API_KEY,
+  baseUrl: 'https://api.openai.com/v1',
+  maxTokens: 1000,
+  temperature: 0.2,
+};
+```
+
+`cost` is the configured cost per 1,000 tokens used for cascade ordering. Provider-reported usage and built-in pricing are used when the provider supports detailed cost calculation.
+
+## Local Endpoints
+
+```typescript
+const local = new CascadeAgent({
+  models: [
+    {
+      name: 'qwen2.5:7b',
+      provider: 'ollama',
+      cost: 0,
+      baseUrl: 'http://localhost:11434',
+    },
+  ],
+});
+```
+
+## Registry
+
+```typescript
+import { getAvailableProviders, providerRegistry } from '@cascadeflow/core';
+
+console.log(getAvailableProviders());
+console.log(providerRegistry.has('openai'));
+```
+
+The `Provider` interface contains `generate()`, optional `stream()`, `calculateCost()`, and `isAvailable()` methods. Register a custom provider class when the built-in providers do not cover your endpoint.
+
+See [Providers and Presets](/developers/providers-and-presets) for configuration patterns.

--- a/docs-site/api-reference/typescript/quality-routing.mdx
+++ b/docs-site/api-reference/typescript/quality-routing.mdx
@@ -1,0 +1,104 @@
+---
+title: Quality and Routing
+description: TypeScript quality validation, semantic checks, complexity detection, routers, rules, and domain configuration.
+---
+
+`CascadeAgent` combines quality validation with pre-routing, tool capability checks, tiers, domains, and custom rules.
+
+## Quality Validation
+
+```typescript
+import { QualityValidator } from '@cascadeflow/core';
+
+const validator = new QualityValidator({
+  minConfidence: 0.7,
+  minWordCount: 10,
+  useLogprobs: true,
+  fallbackToHeuristic: true,
+  strictMode: false,
+  useAlignmentScoring: true,
+  minAlignmentScore: 0.15,
+});
+```
+
+The package also exports `ProductionConfidenceEstimator`, `ResponseAnalyzer`, `QueryResponseAlignmentScorer`, and `ComplexityDetector` for direct use.
+
+## Semantic Validation
+
+Install the optional ML runtime:
+
+```bash
+npm install @cascadeflow/ml @huggingface/transformers
+```
+
+Enable it through agent quality configuration:
+
+```typescript
+const agent = new CascadeAgent({
+  models,
+  quality: {
+    useSemanticValidation: true,
+    semanticThreshold: 0.5,
+  },
+});
+```
+
+Or use the checker directly:
+
+```typescript
+import { SemanticQualityChecker } from '@cascadeflow/core';
+
+const checker = new SemanticQualityChecker();
+if (await checker.isAvailable()) {
+  const result = await checker.checkSimilarity(query, response);
+  console.log(result.similarity, result.passed);
+}
+```
+
+## Routers
+
+| Router | Purpose |
+|---|---|
+| `PreRouter` | Decide whether to cascade or route directly |
+| `ToolRouter` | Filter and rank tool-capable models |
+| `TierRouter` | Apply user-tier constraints |
+| `DomainRouter` | Detect a domain and select domain-specific routing |
+| `RouterChain` | Compose routing decisions |
+
+`CascadeAgent` creates and coordinates these routers from `AgentConfig` and `RunOptions`.
+
+## Domain Configuration
+
+```typescript
+import { CascadeAgent, Domain } from '@cascadeflow/core';
+
+const agent = new CascadeAgent({
+  models,
+  domainConfigs: {
+    [Domain.MATH]: {
+      drafter: 'gpt-4o-mini',
+      verifier: 'gpt-4o',
+      threshold: 0.85,
+    },
+  },
+  enableDomainDetection: true,
+});
+```
+
+The package exports built-in strategies and domain configurations through `BUILT_IN_STRATEGIES` and `BUILTIN_DOMAIN_CONFIGS`.
+
+## Rule Engine
+
+`RuleEngine` applies workflow, tenant, channel, user-tier, and KPI context before model execution.
+
+```typescript
+const result = await agent.run('Handle this request', {
+  userTier: 'premium',
+  workflow: 'support',
+  tenantId: 'tenant-123',
+  channel: 'web',
+  kpiFlags: { priority: 'high' },
+});
+```
+
+Provide `ruleEngineConfig` or a custom `ruleEngine` in `AgentConfig` when the built-in routing rules are not sufficient.

--- a/docs-site/api-reference/typescript/result.mdx
+++ b/docs-site/api-reference/typescript/result.mdx
@@ -1,0 +1,69 @@
+---
+title: CascadeResult
+description: TypeScript CascadeResult fields for output, routing, quality, tools, cost, and latency diagnostics.
+---
+
+`CascadeResult` contains the final content and diagnostics from cascade execution.
+
+## Required Fields
+
+```typescript
+interface CascadeResult {
+  content: string;
+  modelUsed: string;
+  totalCost: number;
+  latencyMs: number;
+  complexity: string;
+  cascaded: boolean;
+  draftAccepted: boolean;
+  routingStrategy: string;
+  reason: string;
+  hasToolCalls: boolean;
+}
+```
+
+## Quality Diagnostics
+
+| Field | Type | Description |
+|---|---|---|
+| `qualityScore` | number | Validator score from 0 to 1 |
+| `qualityThreshold` | number | Threshold applied to the draft |
+| `qualityCheckPassed` | boolean | Whether the draft passed |
+| `rejectionReason` | string | Why the draft was rejected |
+| `draftResponse` | string | Full draft content when retained |
+| `verifierResponse` | string | Full verifier content when retained |
+
+## Cost and Latency
+
+| Field | Type | Description |
+|---|---|---|
+| `draftCost` | number | Draft generation cost |
+| `verifierCost` | number | Verifier generation cost |
+| `costSaved` | number | Estimated savings against direct verifier use |
+| `savingsPercentage` | number | Estimated savings percentage |
+| `draftLatencyMs` | number | Draft latency |
+| `verifierLatencyMs` | number | Verifier latency |
+| `cascadeOverheadMs` | number | Latency spent on a rejected draft |
+| `speedup` | number | Estimated speedup factor |
+
+These diagnostic fields are optional because direct routes and provider limitations may not produce every measurement.
+
+## Tool Calls
+
+```typescript
+if (result.hasToolCalls) {
+  for (const call of result.toolCalls ?? []) {
+    console.log(call.name, call.arguments);
+  }
+}
+```
+
+## Convert to a Plain Object
+
+```typescript
+import { resultToObject } from '@cascadeflow/core';
+
+const payload = resultToObject(result);
+```
+
+`resultToObject()` uses snake_case keys for cross-language serialization.

--- a/docs-site/api-reference/typescript/streaming.mdx
+++ b/docs-site/api-reference/typescript/streaming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Streaming
-description: TypeScript streaming API — StreamEvent, StreamEventType, and async iterators for real-time cascade output.
+description: TypeScript streaming API with StreamEvent, StreamEventType, and async iterators for real-time cascade output.
 ---
 
 # Streaming
@@ -12,7 +12,12 @@ description: TypeScript streaming API — StreamEvent, StreamEventType, and asyn
 ```typescript
 import { CascadeAgent, StreamEventType } from '@cascadeflow/core';
 
-const agent = new CascadeAgent({ models: [...] });
+const agent = new CascadeAgent({
+  models: [
+    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.00015 },
+    { name: 'gpt-4o', provider: 'openai', cost: 0.0025 },
+  ],
+});
 
 for await (const event of agent.streamEvents('Explain TypeScript')) {
   switch (event.type) {
@@ -26,7 +31,8 @@ for await (const event of agent.streamEvents('Explain TypeScript')) {
       console.log(`Draft ${event.data.accepted ? 'accepted' : 'rejected'}`);
       break;
     case StreamEventType.COMPLETE:
-      console.log(`\nModel: ${event.data.model}, Cost: $${event.data.cost}`);
+      console.log(`\nModel: ${event.data.result?.modelUsed}`);
+      console.log(`Cost: $${event.data.result?.totalCost ?? 0}`);
       break;
   }
 }
@@ -64,14 +70,17 @@ interface StreamEvent {
 | Field | Type | Description |
 |---|---|---|
 | `model` | `string` | Current model name |
-| `phase` | `string` | Current phase (`"draft"` or `"verify"`) |
+| `phase` | `string` | Current phase (`draft`, `verifier`, or `direct`) |
 | `strategy` | `string` | Routing strategy used |
 | `accepted` | `boolean` | Whether draft was accepted (on `DRAFT_DECISION`) |
-| `cost` | `number` | Running cost (on `COMPLETE`) |
+| `result` | `CascadeResult` | Final result on `COMPLETE` |
+| `reason` | `string` | Routing or validation reason |
+| `score` | `number` | Quality score when available |
+| `from_model` / `to_model` | `string` | Model transition on `SWITCH` |
 
 ## StreamEventsOptions
 
-Same as `RunOptions` — all parameters from `agent.run()` are accepted.
+Streaming options include the shared generation, knowledge, tool, routing, and provider options from `agent.run()`.
 
 ```typescript
 for await (const event of agent.streamEvents('Query', {

--- a/docs-site/api-reference/typescript/tools.mdx
+++ b/docs-site/api-reference/typescript/tools.mdx
@@ -1,0 +1,85 @@
+---
+title: Tools
+description: Define, format, validate, and execute tools with the TypeScript core package.
+---
+
+## Define a Tool
+
+```typescript
+import { ToolConfig } from '@cascadeflow/core';
+
+const weatherTool = new ToolConfig({
+  name: 'get_weather',
+  description: 'Get the current weather for a city',
+  parameters: {
+    type: 'object',
+    properties: {
+      city: { type: 'string' },
+    },
+    required: ['city'],
+  },
+  function: async ({ city }: { city: string }) => ({ city, temperatureC: 18 }),
+});
+```
+
+`createTool()` provides an equivalent function-based constructor. The `tool()` helper can infer a schema from examples.
+
+## Execute Tools Automatically
+
+```typescript
+import { CascadeAgent, ToolExecutor } from '@cascadeflow/core';
+
+const executor = new ToolExecutor([weatherTool]);
+const agent = new CascadeAgent({
+  models,
+  toolExecutor: executor,
+});
+
+const result = await agent.run('What is the weather in Zurich?', {
+  tools: [weatherTool.toOpenAIFormat()],
+  maxSteps: 5,
+});
+```
+
+## Execute a Parsed Call
+
+```typescript
+import { ToolCall, ToolCallFormat } from '@cascadeflow/core';
+
+const call = new ToolCall({
+  id: 'call_1',
+  name: 'get_weather',
+  arguments: { city: 'Zurich' },
+  providerFormat: ToolCallFormat.OPENAI,
+});
+
+const toolResult = await executor.execute(call);
+console.log(toolResult.success, toolResult.result);
+```
+
+`executeParallel()` runs multiple independent tool calls concurrently.
+
+## Provider Formats
+
+```typescript
+import {
+  toAnthropicFormat,
+  toOllamaFormat,
+  toOpenAIFormat,
+  toProviderFormat,
+} from '@cascadeflow/core';
+```
+
+The format helpers convert the universal tool definition for provider APIs.
+
+## Validation and Tool Cascading
+
+The core package also exports:
+
+- `ToolValidator` for quality and completeness checks.
+- `ToolCallDetector` for detecting tool intent.
+- `ToolCascadeRouter` for model and risk-tier selection.
+- `ToolCascadeValidator` for validating generated tool calls.
+- `ToolCascade` for the combined tool cascade pipeline.
+
+See [Tools and Streaming](/developers/tools-and-streaming) for agent-loop patterns.

--- a/docs-site/api-reference/typescript/vercel-ai.mdx
+++ b/docs-site/api-reference/typescript/vercel-ai.mdx
@@ -37,15 +37,26 @@ const handler = createChatHandler(agent, {
 ## Options
 
 ```typescript
-interface ChatHandlerOptions {
-  protocol: 'data' | 'ui';             // AI SDK stream protocol
-  tools?: ToolDefinition[];             // Tool definitions
-  toolHandlers?: Record<string, Function>; // Server-side tool execution
-  toolExecutor?: Function;              // Universal tool executor
-  maxSteps?: number;                    // Multi-step tool loop limit
-  forceDirect?: boolean;                // Skip cascade, use verifier
-  allowOverrides?: string[];            // Request-level override keys
-  overrideSecret?: string;              // Shared secret for overrides
+interface VercelAIChatHandlerOptions {
+  protocol?: 'data' | 'text';
+  stream?: boolean;
+  systemPrompt?: string;
+  maxTokens?: number;
+  temperature?: number;
+  tools?: Tool[];
+  extra?: Record<string, any>;
+  toolExecutor?: ToolExecutor;
+  toolHandlers?: Record<string, (args: Record<string, any>) => unknown | Promise<unknown>>;
+  maxSteps?: number;
+  forceDirect?: boolean;
+  userTier?: string;
+  emitCascadeEvents?: boolean;
+  requestOverrides?: {
+    enabled?: boolean;
+    secret?: string;
+    headerName?: string;
+    allowedFields?: Array<'forceDirect' | 'maxSteps' | 'userTier'>;
+  };
 }
 ```
 

--- a/docs-site/comparisons/litellm.mdx
+++ b/docs-site/comparisons/litellm.mdx
@@ -197,7 +197,7 @@ with cascadeflow.run(budget=1.00, compliance="gdpr", max_tool_calls=10) as sessi
 import { init, run } from '@cascadeflow/core';
 
 // Initialize with enforcement mode
-init({ mode: 'enforce', budget: 1.0, compliance: 'gdpr' });
+init({ mode: 'enforce', budget: 1.0, compliance: 'regulated' });
 
 // Run with scoped session for governance
 const result = await run({ budget: 0.50 }, async (ctx) => {

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -140,10 +140,17 @@
             "pages": [
               "api-reference/typescript/overview",
               "api-reference/typescript/core",
+              "api-reference/typescript/harness",
+              "api-reference/typescript/cascade-agent",
+              "api-reference/typescript/configuration",
+              "api-reference/typescript/result",
+              "api-reference/typescript/providers",
+              "api-reference/typescript/tools",
+              "api-reference/typescript/quality-routing",
+              "api-reference/typescript/streaming",
               "api-reference/typescript/vercel-ai",
               "api-reference/typescript/langchain",
-              "api-reference/typescript/streaming",
-              "api-reference/typescript/configuration"
+              "api-reference/typescript/feature-parity"
             ]
           }
         ]

--- a/docs-site/examples/catalog.mdx
+++ b/docs-site/examples/catalog.mdx
@@ -78,3 +78,17 @@ The complete index of cascadeflow examples across Python, TypeScript, integratio
 | Browser and edge examples | [packages/core/examples/browser](https://github.com/lemony-ai/cascadeflow/tree/main/packages/core/examples/browser) |
 | LangChain TypeScript examples | [packages/langchain-cascadeflow/examples](https://github.com/lemony-ai/cascadeflow/tree/main/packages/langchain-cascadeflow/examples) |
 | Vercel AI example app | [examples/vercel-ai-nextjs](https://github.com/lemony-ai/cascadeflow/tree/main/examples/vercel-ai-nextjs) |
+
+### Featured TypeScript Examples
+
+| Example | Source |
+|---|---|
+| Basic cascade | [basic-usage.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/basic-usage.ts) |
+| Agent loop and multi-agent | [agentic-multi-agent.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/agentic-multi-agent.ts) |
+| Batch processing | [batch-processing.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/batch-processing.ts) |
+| Guardrails | [guardrails-usage.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/guardrails-usage.ts) |
+| Routing | [router-integration.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/router-integration.ts) |
+| Semantic validation | [semantic-quality.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/semantic-quality.ts) |
+| Streaming with tools | [streaming-tools.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/streaming-tools.ts) |
+| Telemetry callbacks | [telemetry-callbacks.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/telemetry-callbacks.ts) |
+| User profiles and workflows | [user-profiles-workflows.ts](https://github.com/lemony-ai/cascadeflow/blob/main/packages/core/examples/nodejs/user-profiles-workflows.ts) |

--- a/docs-site/get-started/agent-decorator.mdx
+++ b/docs-site/get-started/agent-decorator.mdx
@@ -1,15 +1,21 @@
 ---
 title: "Quickstart: Agent Decorator"
-description: Attach budget, compliance, and KPI policies directly to agent functions with @cascadeflow.agent().
+description: Attach budget, compliance, and KPI policy metadata directly to agent functions.
 ---
 
-# Agent Decorator — Policy Per Agent
+# Agent Policy Metadata
 
-The `@cascadeflow.agent()` decorator attaches policy metadata directly to agent functions. Each agent gets its own budget, compliance rules, and KPI weights — enforced automatically at runtime.
+The Python `@cascadeflow.agent()` decorator and TypeScript `harnessAgent()` wrapper attach policy metadata directly to a function. They do not create a scoped run or enforce the metadata by themselves.
+
+<Warning>
+Use `run()` around agent execution when budget, compliance, or other controls must be enforced.
+</Warning>
 
 ## Basic Usage
 
-```python
+<CodeGroup>
+
+```python Python
 import cascadeflow
 
 cascadeflow.init(mode="enforce")
@@ -20,20 +26,45 @@ async def my_agent(query: str):
     return await llm.complete(query)
 ```
 
+```typescript TypeScript
+import { harnessAgent, init } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+
+const myAgent = harnessAgent({ budget: 0.20 })(
+  async (query: string) => llm.complete(query),
+);
+```
+
+</CodeGroup>
+
 ## Add Compliance
 
-```python
+<CodeGroup>
+
+```python Python
 @cascadeflow.agent(budget=0.50, compliance="gdpr")
 async def eu_agent(query: str):
     """Process EU data — only GDPR-approved models, $0.50 max."""
     return await llm.complete(query)
 ```
 
+```typescript TypeScript
+const regulatedAgent = harnessAgent({
+  budget: 0.50,
+  compliance: 'regulated',
+})(async (query: string) => llm.complete(query));
+```
+
+</CodeGroup>
+
 ## Add KPI Weights
 
 Encode business priorities into how the agent makes model decisions:
 
-```python
+<CodeGroup>
+
+```python Python
 @cascadeflow.agent(
     budget=1.00,
     kpi_weights={"quality": 0.8, "cost": 0.2},
@@ -44,9 +75,19 @@ async def premium_agent(query: str):
     return await llm.complete(query)
 ```
 
+```typescript TypeScript
+const premiumAgent = harnessAgent({
+  budget: 1.00,
+  kpiWeights: { quality: 0.8, cost: 0.2 },
+  kpiTargets: { quality: 0.9 },
+})(async (query: string) => llm.complete(query));
+```
+
+</CodeGroup>
+
 ## Different Agents, Different Policies
 
-The real power shows with multiple agents — each governed independently:
+Multiple functions can carry different policy metadata:
 
 ```python
 @cascadeflow.agent(
@@ -78,18 +119,26 @@ async def research_agent(query: str):
 
 ## Combine with run()
 
-The decorator works alongside `cascadeflow.run()` — the run's constraints apply in addition to the decorator's:
+Create a scoped run around the function invocation to enforce runtime controls:
 
 ```python
 @cascadeflow.agent(budget=0.50, compliance="gdpr")
 async def my_agent(query: str):
     return await llm.complete(query)
 
-# The run adds an outer budget cap on top of the agent's own cap
+# The run creates the active enforcement scope.
 with cascadeflow.run(budget=2.00) as session:
-    await my_agent("First query")   # Agent cap: $0.50, Run cap: $2.00
-    await my_agent("Second query")  # Agent cap: $0.50, Run cap: $2.00 minus first query
+    await my_agent("First query")
+    await my_agent("Second query")
     print(session.summary())
+```
+
+```typescript TypeScript
+await run({ budget: 2.00 }, async (session) => {
+  await myAgent('First query');
+  await myAgent('Second query');
+  console.log(session.summary());
+});
 ```
 
 ## All Decorator Parameters
@@ -102,8 +151,10 @@ with cascadeflow.run(budget=2.00) as session:
 | `kpi_targets` | `dict` | Target values per KPI dimension |
 | `max_tool_calls` | `int` | Max tool/function calls per invocation |
 
+TypeScript uses camelCase parameter names and exports the wrapper as `harnessAgent`.
+
 <Tip>
-**API reference:** [@cascadeflow.agent()](/api-reference/python/agent-decorator) | **Example:** [examples/agentic_multi_agent.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/agentic_multi_agent.py)
+**Python API:** [@cascadeflow.agent()](/api-reference/python/agent-decorator) | **TypeScript API:** [Harness](/api-reference/typescript/harness)
 </Tip>
 
 ## Next Step

--- a/docs-site/get-started/agent-harness.mdx
+++ b/docs-site/get-started/agent-harness.mdx
@@ -5,24 +5,26 @@ description: The runtime governance layer that tracks, scores, and enforces cons
 
 # Agent Harness
 
-The Harness is the core of cascadeflow's runtime intelligence. It wraps agent execution and makes a **decision at every step** — should this model call proceed, be switched, or be stopped?
+The Harness is the core of cascadeflow's runtime intelligence. It wraps agent execution and decides whether a model call should proceed, switch models, remove tools, or stop.
 
 ## What the Harness Does
 
 At every LLM call or tool execution inside an agent loop, the Harness:
 
-1. **Checks hard constraints** — budget remaining, compliance allowlist, tool call cap, latency limit, energy limit
-2. **Scores soft dimensions** — quality, cost, latency, energy weighted by KPI priorities
-3. **Decides an action** — `allow`, `switch_model`, `deny_tool`, or `stop`
-4. **Records a trace** — action, reason, model, step, cost, budget state
+1. **Checks hard constraints**: Budget remaining, compliance allowlist, tool-call cap, latency limit, and energy limit.
+2. **Scores soft dimensions**: Quality, cost, latency, and energy weighted by KPI priorities.
+3. **Decides an action**: `allow`, `switch_model`, `deny_tool`, or `stop`.
+4. **Records a trace**: Action, reason, model, step, cost, and budget state.
 
 In `observe` mode, decisions are recorded but not enforced. In `enforce` mode, they shape execution in real time.
 
-## HarnessConfig — The Full Control Surface
+## HarnessConfig
 
-All Harness behavior is configured through a single dataclass:
+Harness behavior is configured through one language-specific object.
 
-```python
+<CodeGroup>
+
+```python Python
 from cascadeflow import HarnessConfig
 
 config = HarnessConfig(
@@ -36,7 +38,7 @@ config = HarnessConfig(
     max_energy=100.0,                   # Max energy units
 
     # Soft scoring
-    kpi_weights={                       # Relative importance (must sum to ~1.0)
+    kpi_weights={                       # Relative importance
         "quality": 0.6,
         "cost": 0.3,
         "latency": 0.1,
@@ -48,23 +50,53 @@ config = HarnessConfig(
 )
 ```
 
+```typescript TypeScript
+import type { HarnessConfig } from '@cascadeflow/core';
+
+const config: HarnessConfig = {
+  mode: 'enforce',
+  verbose: false,
+  budget: 0.50,
+  maxToolCalls: 10,
+  maxLatencyMs: 5000,
+  maxEnergy: 100,
+  kpiWeights: { quality: 0.6, cost: 0.3, latency: 0.1 },
+  compliance: 'regulated',
+};
+```
+
+</CodeGroup>
+
 ## The Three-Tier API
 
-cascadeflow offers three levels of control — use the one that fits your needs:
+cascadeflow offers three levels of control. Use the one that fits your needs.
 
 ### Tier 1: Global Init (Zero-Change)
 
-```python
+<CodeGroup>
+
+```python Python
 import cascadeflow
 cascadeflow.init(mode="observe")
 # All LLM calls are tracked. Nothing changes.
 ```
 
+```typescript TypeScript
+import { init } from '@cascadeflow/core';
+
+init({ mode: 'observe' });
+// Instrumented OpenAI and Anthropic SDK calls are tracked.
+```
+
+</CodeGroup>
+
 Best for: first rollout, measuring baseline costs, auditing compliance.
 
 ### Tier 2: Scoped Run (Block-Level Control)
 
-```python
+<CodeGroup>
+
+```python Python
 cascadeflow.init(mode="enforce")
 
 with cascadeflow.run(budget=0.50, compliance="gdpr") as session:
@@ -72,11 +104,26 @@ with cascadeflow.run(budget=0.50, compliance="gdpr") as session:
     print(session.summary())
 ```
 
+```typescript TypeScript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+
+await run({ budget: 0.50, compliance: 'regulated' }, async (session) => {
+  await agent.run('Analyze regulated data');
+  console.log(session.summary());
+});
+```
+
+</CodeGroup>
+
 Best for: per-request budgets, scoped policy, session-level metrics.
 
 ### Tier 3: Agent Decorator (Per-Agent Policy)
 
-```python
+<CodeGroup>
+
+```python Python
 @cascadeflow.agent(
     budget=1.00,
     compliance="hipaa",
@@ -86,7 +133,19 @@ async def medical_agent(query: str):
     return await llm.complete(query)
 ```
 
-Best for: multi-agent systems where each agent has different constraints.
+```typescript TypeScript
+import { harnessAgent } from '@cascadeflow/core';
+
+const medicalAgent = harnessAgent({
+  budget: 1.00,
+  compliance: 'regulated',
+  kpiWeights: { quality: 0.8, cost: 0.2 },
+})(async (query: string) => llm.complete(query));
+```
+
+</CodeGroup>
+
+Best for: Attaching policy metadata in multi-agent systems. Use a scoped `run()` when the policy must be enforced.
 
 ## Decision Priority
 
@@ -95,8 +154,8 @@ When the Harness evaluates a step, it follows a strict priority order:
 | Priority | Check | Action if violated |
 |---|---|---|
 | 1 | Budget exhausted | `stop` |
-| 2 | Compliance allowlist | `switch_model` or `stop` |
-| 3 | Tool call cap | `deny_tool` |
+| 2 | Tool call cap | `deny_tool` |
+| 3 | Compliance allowlist | `switch_model`, `deny_tool`, or `stop` |
 | 4 | Latency limit | `switch_model` |
 | 5 | Energy limit | `switch_model` |
 | 6 | KPI scoring | `allow` or `switch_model` |
@@ -129,7 +188,7 @@ Hard constraints (budget, compliance) always take priority over soft scoring (KP
 Start with `observe` to validate your policies against real traffic. Switch to `enforce` when you are confident the rules are correct.
 
 <Tip>
-**Run this example:** [examples/enforcement/basic_enforcement.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/enforcement/basic_enforcement.py) | **API reference:** [HarnessConfig](/api-reference/python/harness-config)
+**Python API:** [HarnessConfig](/api-reference/python/harness-config) | **TypeScript API:** [Harness](/api-reference/typescript/harness) | **Parity notes:** [Python and TypeScript Parity](/api-reference/typescript/feature-parity)
 </Tip>
 
 ## Next Step

--- a/docs-site/get-started/agent-loop.mdx
+++ b/docs-site/get-started/agent-loop.mdx
@@ -54,7 +54,7 @@ with cascadeflow.run(budget=1.00, max_tool_calls=5) as session:
 
     summary = session.summary()
     print(f"Tool calls used: {summary['tool_calls']}/5")
-    print(f"Budget used: ${summary['cost_total']:.4f}/$1.00")
+    print(f"Budget used: ${summary['cost']:.4f}/$1.00")
 ```
 
 When the tool call cap is reached, cascadeflow issues a `deny_tool` action — the agent continues with what it has instead of making more calls.
@@ -116,7 +116,7 @@ with cascadeflow.run(budget=2.00) as session:
         tools=tools,
     )
     # session.summary() includes costs from main_agent AND researcher
-    print(f"Total cost across all agents: ${session.summary()['cost_total']:.4f}")
+    print(f"Total cost across all agents: ${session.summary()['cost']:.4f}")
 ```
 
 ## Model Switching Mid-Loop
@@ -186,14 +186,66 @@ with cascadeflow.run(
     )
 
     summary = session.summary()
-    print(f"Cost: ${summary['cost_total']:.4f} / $1.00")
-    print(f"Steps: {summary['steps']}")
+    print(f"Cost: ${summary['cost']:.4f} / $1.00")
+    print(f"Steps: {summary['step_count']}")
     print(f"Tool calls: {summary['tool_calls']} / 8")
     print(f"Budget remaining: ${summary['budget_remaining']:.4f}")
 ```
 
+## Complete TypeScript Loop
+
+```typescript
+import {
+  CascadeAgent,
+  ToolConfig,
+  ToolExecutor,
+  init,
+  run,
+} from '@cascadeflow/core';
+
+const searchTool = new ToolConfig({
+  name: 'search',
+  description: 'Search a data source',
+  parameters: {
+    type: 'object',
+    properties: { query: { type: 'string' } },
+    required: ['query'],
+  },
+  function: async ({ query }: { query: string }) => `Results for ${query}`,
+});
+
+const executor = new ToolExecutor([searchTool]);
+const agent = new CascadeAgent({
+  models: [
+    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.00015, supportsTools: true },
+    { name: 'gpt-4o', provider: 'openai', cost: 0.0025, supportsTools: true },
+  ],
+  toolExecutor: executor,
+});
+
+init({ mode: 'enforce' });
+
+await run({
+  budget: 1.00,
+  maxToolCalls: 8,
+  compliance: 'regulated',
+  kpiWeights: { quality: 0.6, cost: 0.3, latency: 0.1 },
+}, async (session) => {
+  await agent.run('Research market data', {
+    tools: [searchTool.toOpenAIFormat()],
+    maxSteps: 15,
+  });
+
+  const summary = session.summary();
+  console.log(`Cost: $${summary.cost.toFixed(4)} / $1.00`);
+  console.log(`Steps: ${summary.stepCount}`);
+  console.log(`Tool calls: ${summary.toolCalls} / 8`);
+  console.log(`Budget remaining: $${summary.budgetRemaining?.toFixed(4)}`);
+});
+```
+
 <Tip>
-**Run these examples:** [examples/agentic_multi_agent.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/agentic_multi_agent.py) | [examples/tool_execution.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/tool_execution.py) | [examples/multi_step_cascade.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/multi_step_cascade.py)
+**Python examples:** [examples/agentic_multi_agent.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/agentic_multi_agent.py) | **TypeScript guide:** [Agentic Patterns](https://github.com/lemony-ai/cascadeflow/blob/main/docs/guides/agentic-typescript.md)
 </Tip>
 
 ## Next Step

--- a/docs-site/get-started/enforce.mdx
+++ b/docs-site/get-started/enforce.mdx
@@ -11,17 +11,29 @@ Enforce mode moves from observation to action. Budget caps, tool call limits, an
 
 <Step title="Switch to enforce">
 
+<CodeGroup>
+
 ```python
 import cascadeflow
 
 cascadeflow.init(mode="enforce")  # Changed from "observe" to "enforce"
 ```
 
+```typescript TypeScript
+import { init } from '@cascadeflow/core';
+
+init({ mode: 'enforce' }); // Changed from 'observe' to 'enforce'
+```
+
+</CodeGroup>
+
 </Step>
 
 <Step title="Add a budget cap">
 
 Wrap any block of agent work with `cascadeflow.run()` and set a budget:
+
+<CodeGroup>
 
 ```python
 cascadeflow.init(mode="enforce")
@@ -30,12 +42,29 @@ with cascadeflow.run(budget=0.50) as session:
     result = await agent.run("Research and summarize this topic")
 
     summary = session.summary()
-    print(f"Cost: ${summary['cost_total']:.4f}")
+    print(f"Cost: ${summary['cost']:.4f}")
     print(f"Budget remaining: ${summary['budget_remaining']:.4f}")
-    print(f"Steps completed: {summary['steps']}")
+    print(f"Steps completed: {summary['step_count']}")
 ```
 
-If the agent exceeds $0.50, cascadeflow issues a `stop` action. The agent halts cleanly — no runaway spend.
+```typescript TypeScript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+
+await run({ budget: 0.50 }, async (session) => {
+  await agent.run('Research and summarize this topic');
+
+  const summary = session.summary();
+  console.log(`Cost: $${summary.cost.toFixed(4)}`);
+  console.log(`Budget remaining: $${summary.budgetRemaining?.toFixed(4)}`);
+  console.log(`Steps completed: ${summary.stepCount}`);
+});
+```
+
+</CodeGroup>
+
+If the agent exceeds $0.50, cascadeflow issues a `stop` action. The agent halts cleanly and prevents runaway spend.
 
 </Step>
 
@@ -45,6 +74,13 @@ If the agent exceeds $0.50, cascadeflow issues a `stop` action. The agent halts 
 with cascadeflow.run(budget=1.00, max_tool_calls=5) as session:
     result = await agent.run("Search and analyze this dataset")
     # Stops when either budget OR tool call limit is hit first
+```
+
+```typescript TypeScript
+await run({ budget: 1.00, maxToolCalls: 5 }, async () => {
+  await agent.run('Search and analyze this dataset');
+  // Stops when either the budget or tool-call limit is hit first.
+});
 ```
 
 </Step>
@@ -57,6 +93,13 @@ Restrict which models can process sensitive data:
 with cascadeflow.run(budget=1.00, compliance="gdpr") as session:
     result = await agent.run("Process EU customer feedback")
     # Only GDPR-approved models are allowed — non-compliant models are switched
+```
+
+```typescript TypeScript
+await run({ budget: 1.00, compliance: 'regulated' }, async () => {
+  await agent.run('Process EU customer feedback');
+  // Only models in the TypeScript regulated profile are allowed.
+});
 ```
 
 </Step>
@@ -98,28 +141,8 @@ with cascadeflow.run(budget=1.00, max_tool_calls=10, compliance="gdpr") as sessi
     ...
 ```
 
-## TypeScript
-
-```typescript
-import { CascadeAgent } from '@cascadeflow/core';
-
-const agent = new CascadeAgent({
-  models: [
-    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.000375 },
-    { name: 'gpt-4o', provider: 'openai', cost: 0.00625 },
-  ],
-  quality: {
-    threshold: 0.8,
-    useSemanticValidation: true,
-  },
-});
-
-const result = await agent.run('Explain quantum computing');
-console.log(`Model: ${result.modelUsed}, Saved: ${result.savingsPercentage}%`);
-```
-
 <Tip>
-**Run this example:** [examples/enforcement/basic_enforcement.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/enforcement/basic_enforcement.py) | [examples/user_budget_tracking.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/user_budget_tracking.py)
+The TypeScript `run()` API takes a callback so the scoped context follows asynchronous work through `AsyncLocalStorage` in Node.js.
 </Tip>
 
 ## Next Step

--- a/docs-site/get-started/installation.mdx
+++ b/docs-site/get-started/installation.mdx
@@ -76,6 +76,12 @@ npm install @cascadeflow/vercel-ai                 # Vercel AI SDK middleware
 npm install @cascadeflow/n8n-nodes-cascadeflow     # n8n community node
 ```
 
+### Optional semantic validation
+
+```bash
+npm install @cascadeflow/ml @huggingface/transformers
+```
+
 ## Provider Setup
 
 Set API keys as environment variables:
@@ -96,6 +102,10 @@ python -c "import cascadeflow; print(cascadeflow.__version__)"
 
 ```bash
 python -c "from cascadeflow import init, run, HarnessConfig, HarnessRunContext; print('OK')"
+```
+
+```bash
+node -e "const c = require('@cascadeflow/core'); console.log(typeof c.init, typeof c.run)"
 ```
 
 ## Next Step

--- a/docs-site/get-started/observe.mdx
+++ b/docs-site/get-started/observe.mdx
@@ -14,9 +14,11 @@ Observe mode tracks every LLM call without blocking or modifying any behavior. T
 
 <Steps>
 
-<Step title="Add one line">
+<Step title="Initialize observe mode">
 
 Add `cascadeflow.init(mode="observe")` before any LLM calls in your application:
+
+<CodeGroup>
 
 ```python
 import cascadeflow
@@ -34,6 +36,24 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
+```typescript TypeScript
+import OpenAI from 'openai';
+import { init } from '@cascadeflow/core';
+
+init({ mode: 'observe' });
+
+// Your existing code remains unchanged.
+const client = new OpenAI();
+const response = await client.chat.completions.create({
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: 'What is cascadeflow?' }],
+});
+
+console.log(response.choices[0]?.message.content);
+```
+
+</CodeGroup>
+
 Every call is now tracked. Nothing is blocked or changed.
 
 </Step>
@@ -41,6 +61,8 @@ Every call is now tracked. Nothing is blocked or changed.
 <Step title="See what you spend">
 
 Wrap a block with `cascadeflow.run()` to get aggregate metrics:
+
+<CodeGroup>
 
 ```python
 import cascadeflow
@@ -59,11 +81,36 @@ with cascadeflow.run() as session:
     )
 
     summary = session.summary()
-    print(f"Total cost:    ${summary['cost_total']:.4f}")
-    print(f"LLM calls:     {summary['steps']}")
-    print(f"Total latency: {summary['latency_total_ms']:.0f}ms")
+    print(f"Total cost:    ${summary['cost']:.4f}")
+    print(f"LLM calls:     {summary['step_count']}")
+    print(f"Total latency: {summary['latency_used_ms']:.0f}ms")
     print(f"Energy used:   {summary['energy_used']:.1f} units")
 ```
+
+```typescript TypeScript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'observe' });
+
+await run(async (session) => {
+  await client.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: 'Summarize this document' }],
+  });
+  await client.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content: 'Analyze the sentiment' }],
+  });
+
+  const summary = session.summary();
+  console.log(`Total cost:    $${summary.cost.toFixed(4)}`);
+  console.log(`LLM calls:     ${summary.stepCount}`);
+  console.log(`Total latency: ${summary.latencyUsedMs.toFixed(0)}ms`);
+  console.log(`Energy used:   ${summary.energyUsed.toFixed(1)} units`);
+});
+```
+
+</CodeGroup>
 
 </Step>
 
@@ -71,12 +118,24 @@ with cascadeflow.run() as session:
 
 Even in observe mode, cascadeflow records what it **would** have done:
 
+<CodeGroup>
+
 ```python
 for record in session.trace():
-    print(f"Step {record['step']}: {record['action']} — {record['reason']}")
+    print(f"Step {record['step']}: {record['action']}: {record['reason']}")
     print(f"  Model: {record['model']}, Cost so far: ${record['cost_total']:.4f}")
     print(f"  Applied: {record['applied']}")  # Always False in observe mode
 ```
+
+```typescript TypeScript
+for (const record of session.trace()) {
+  console.log(`Step ${record.step}: ${record.action}: ${record.reason}`);
+  console.log(`  Model: ${record.model}, Cost so far: $${record.costTotal.toFixed(4)}`);
+  console.log(`  Applied: ${record.applied}`); // Always false in observe mode
+}
+```
+
+</CodeGroup>
 
 This lets you audit compliance violations, budget overruns, and routing decisions before turning on enforcement.
 
@@ -84,26 +143,8 @@ This lets you audit compliance violations, budget overruns, and routing decision
 
 </Steps>
 
-## TypeScript
-
-```typescript
-import { CascadeAgent } from '@cascadeflow/core';
-
-const agent = new CascadeAgent({
-  models: [
-    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.000375 },
-    { name: 'gpt-4o', provider: 'openai', cost: 0.00625 },
-  ],
-});
-
-const result = await agent.run('What is TypeScript?');
-console.log(`Model: ${result.modelUsed}`);
-console.log(`Cost: $${result.totalCost}`);
-console.log(`Saved: ${result.savingsPercentage}%`);
-```
-
 <Tip>
-**Run this example:** [examples/basic_usage.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/basic_usage.py) | [examples/cost_tracking.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/cost_tracking.py)
+The TypeScript harness instruments the OpenAI and Anthropic SDKs. Use `CascadeAgent` separately when you want speculative model cascading.
 </Tip>
 
 ## What You Learn in Observe Mode

--- a/docs-site/harness/actions.mdx
+++ b/docs-site/harness/actions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Decision Actions
-description: Four harness actions — allow, switch_model, deny_tool, and stop — and when each is triggered.
+description: Four harness actions: allow, switch_model, deny_tool, and stop, including when each is triggered.
 ---
 
 The harness makes one of four decisions at every step. Actions are computed in both `observe` and `enforce` modes, but only applied in `enforce` mode.
@@ -12,7 +12,7 @@ The harness makes one of four decisions at every step. Actions are computed in b
 Proceed normally. No constraints are violated.
 
 ```
-Step 1: allow — budget ok, model compliant
+Step 1: allow: observe
 ```
 
 This is the most common action. It means all hard caps (budget, tool calls, latency, energy) are within limits and compliance is satisfied.
@@ -25,7 +25,7 @@ Route to a different model. Triggered when:
 - Budget pressure suggests a cheaper alternative
 
 ```
-Step 3: switch_model — compliance violation, switching to gpt-4o-mini (gdpr allowlist)
+Step 3: switch_model: compliance_model_policy
 ```
 
 In `enforce` mode, the harness substitutes the model. In `observe` mode, the original model is used and the trace records what would have happened.
@@ -35,7 +35,7 @@ In `enforce` mode, the harness substitutes the model. In `observe` mode, the ori
 Block a tool/function call. Triggered when `max_tool_calls` is reached.
 
 ```
-Step 5: deny_tool — tool call cap reached (10/10)
+Step 5: deny_tool: max_tool_calls_reached
 ```
 
 In `enforce` mode, the tool call is blocked. The agent receives a signal that the tool was denied.
@@ -48,7 +48,7 @@ Halt agent execution. Triggered when:
 - Energy cap is exceeded
 
 ```
-Step 7: stop — budget exceeded ($0.52 > $0.50 cap)
+Step 7: stop: budget_exceeded
 ```
 
 In `enforce` mode, the agent loop is stopped. In `observe` mode, execution continues and the trace records the violation.
@@ -57,12 +57,13 @@ In `enforce` mode, the agent loop is stopped. In `observe` mode, execution conti
 
 When multiple constraints are violated simultaneously, the harness applies this priority:
 
-1. **Compliance** — check first (switch_model or stop)
-2. **Budget** — check second (stop)
-3. **Tool calls** — check third (deny_tool)
-4. **Latency** — check fourth (stop)
-5. **Energy** — check fifth (stop)
-6. **KPI scoring** — soft optimization (switch_model or allow)
+1. **Budget**: Stop when the budget is exhausted.
+2. **Tool calls**: Remove tools when the tool-call cap is reached.
+3. **Compliance**: Switch models, remove tools, or stop according to the profile.
+4. **Latency**: Switch to a faster model or stop.
+5. **Energy**: Switch to a lower-energy model or stop.
+6. **Budget pressure**: Switch to a cheaper model below 20 percent remaining budget.
+7. **KPI scoring**: Apply soft model optimization.
 
 ## Hard vs Soft Controls
 
@@ -75,11 +76,13 @@ When multiple constraints are violated simultaneously, the harness applies this 
 
 **Soft controls** influence model selection through KPI weights but never block execution:
 - `kpi_weights` — relative importance of quality, cost, latency, energy
-- `kpi_targets` — target values for KPI dimensions
+- `kpi_targets` / `kpiTargets`: policy metadata retained in the run context
 
 ## Example: Combined Constraints
 
-```python
+<CodeGroup>
+
+```python Python
 import cascadeflow
 
 cascadeflow.init(mode="enforce")
@@ -93,8 +96,29 @@ with cascadeflow.run(
     result = await agent.run("Process EU customer data")
 
     for record in session.trace():
-        print(f"Step {record['step']}: {record['action']} — {record['reason']}")
+        print(f"Step {record['step']}: {record['action']}: {record['reason']}")
 ```
+
+```typescript TypeScript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+
+await run({
+  budget: 1.00,
+  maxToolCalls: 5,
+  compliance: 'regulated',
+  kpiWeights: { quality: 0.6, cost: 0.4 },
+}, async (session) => {
+  await agent.run('Process regulated customer data');
+
+  for (const record of session.trace()) {
+    console.log(`Step ${record.step}: ${record.action}: ${record.reason}`);
+  }
+});
+```
+
+</CodeGroup>
 
 <Tip>
 **Examples on GitHub:** [examples/enforcement/basic_enforcement.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/enforcement/basic_enforcement.py) | [examples/agentic_multi_agent.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/agentic_multi_agent.py)

--- a/docs-site/harness/budget-enforcement.mdx
+++ b/docs-site/harness/budget-enforcement.mdx
@@ -21,23 +21,22 @@ with cascadeflow.run(budget=0.50) as session:
     result = await agent.run("Research and summarize this topic")
 
     summary = session.summary()
-    print(f"Total cost: ${summary['cost_total']:.4f}")
+    print(f"Total cost: ${summary['cost']:.4f}")
     print(f"Budget remaining: ${summary['budget_remaining']:.4f}")
 ```
 
 ```typescript TypeScript
-import { CascadeAgent } from '@cascadeflow/core';
+import { init, run } from '@cascadeflow/core';
 
-const agent = new CascadeAgent({
-  models: [
-    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.000375 },
-    { name: 'gpt-4o', provider: 'openai', cost: 0.00625 },
-  ],
-  quality: { threshold: 0.8 },
+init({ mode: 'enforce' });
+
+await run({ budget: 0.50 }, async (session) => {
+  await agent.run('Research and summarize this topic');
+
+  const summary = session.summary();
+  console.log(`Total cost: $${summary.cost.toFixed(4)}`);
+  console.log(`Budget remaining: $${summary.budgetRemaining?.toFixed(4)}`);
 });
-
-const result = await agent.run('Research and summarize this topic');
-console.log(`Cost: $${result.totalCost}, Saved: ${result.savingsPercentage}%`);
 ```
 
 </CodeGroup>
@@ -50,6 +49,8 @@ When cumulative cost exceeds the budget:
 
 Attach budget metadata to agent functions:
 
+<CodeGroup>
+
 ```python
 @cascadeflow.agent(budget=0.20)
 async def cheap_agent(query: str):
@@ -60,11 +61,31 @@ async def premium_agent(query: str):
     return await llm.complete(query)
 ```
 
+```typescript TypeScript
+import { harnessAgent } from '@cascadeflow/core';
+
+const cheapAgent = harnessAgent({ budget: 0.20 })(
+  async (query: string) => llm.complete(query),
+);
+
+const premiumAgent = harnessAgent({ budget: 2.00 })(
+  async (query: string) => llm.complete(query),
+);
+```
+
+</CodeGroup>
+
+<Note>
+The agent decorator and `harnessAgent()` attach policy metadata. Use `run()` to create and enforce a scoped run.
+</Note>
+
 ## Budget Pressure Routing
 
 When budget is partially consumed, the harness can route to cheaper models. This happens automatically when KPI weights include a cost dimension:
 
-```python
+<CodeGroup>
+
+```python Python
 cascadeflow.init(mode="enforce")
 
 with cascadeflow.run(
@@ -76,6 +97,21 @@ with cascadeflow.run(
     for query in queries:
         result = await agent.run(query)
 ```
+
+```typescript TypeScript
+init({ mode: 'enforce' });
+
+await run({
+  budget: 1.00,
+  kpiWeights: { quality: 0.5, cost: 0.5 },
+}, async () => {
+  for (const query of queries) {
+    await agent.run(query);
+  }
+});
+```
+
+</CodeGroup>
 
 ## Cost Calculation
 
@@ -91,11 +127,21 @@ The pricing table covers 18 models across OpenAI, Anthropic, and Google. Unknown
 
 Budget and tool call caps work together:
 
-```python
+<CodeGroup>
+
+```python Python
 with cascadeflow.run(budget=0.50, max_tool_calls=10) as session:
     # Stops when either limit is hit
     result = await agent.run("Analyze this data")
 ```
+
+```typescript TypeScript
+await run({ budget: 0.50, maxToolCalls: 10 }, async () => {
+  await agent.run('Analyze this data');
+});
+```
+
+</CodeGroup>
 
 The harness checks all constraints at every step. The first constraint that is violated triggers the corresponding action (`stop` for budget, `deny_tool` for tool calls).
 

--- a/docs-site/harness/compliance.mdx
+++ b/docs-site/harness/compliance.mdx
@@ -5,7 +5,7 @@ description: GDPR, HIPAA, PCI, and strict model allowlists for compliance-aware 
 
 The harness enforces model allowlists based on compliance requirements. When a compliance mode is set, only models in the corresponding allowlist are permitted.
 
-## Compliance Modes
+## Python Compliance Modes
 
 | Mode | Allowed Models | Use Case |
 |---|---|---|
@@ -14,9 +14,22 @@ The harness enforces model allowlists based on compliance requirements. When a c
 | `pci` | gpt-4o-mini, gpt-3.5-turbo | Payment card data |
 | `strict` | gpt-4o | Maximum restriction |
 
+## TypeScript Compliance Modes
+
+| Mode | Allowed Models | Tool Policy |
+|---|---|---|
+| `regulated` | gpt-4o, Claude Sonnet 4.5 | Allowed |
+| `strict` | gpt-4o, gpt-4o-mini, Claude Sonnet 4.5, Claude Haiku 4.5 | Denied |
+
+<Warning>
+Compliance profile names currently differ between the Python and TypeScript harnesses. TypeScript does not currently implement the `gdpr`, `hipaa`, or `pci` profiles. An unknown TypeScript profile does not apply an allowlist.
+</Warning>
+
 ## Usage
 
-```python
+<CodeGroup>
+
+```python Python
 import cascadeflow
 
 cascadeflow.init(mode="enforce")
@@ -26,13 +39,37 @@ with cascadeflow.run(compliance="gdpr") as session:
     result = await agent.run("Process this EU customer data")
 ```
 
+```typescript TypeScript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+
+await run({ compliance: 'regulated' }, async () => {
+  await agent.run('Process this regulated customer data');
+});
+```
+
+</CodeGroup>
+
 Or as agent metadata:
 
-```python
+<CodeGroup>
+
+```python Python
 @cascadeflow.agent(compliance="hipaa")
 async def medical_agent(query: str):
     return await llm.complete(query)
 ```
+
+```typescript TypeScript
+import { harnessAgent } from '@cascadeflow/core';
+
+const regulatedAgent = harnessAgent({ compliance: 'regulated' })(
+  async (query: string) => llm.complete(query),
+);
+```
+
+</CodeGroup>
 
 ## Enforcement Behavior
 
@@ -45,22 +82,30 @@ When a model outside the allowlist is requested:
 
 Compliance and budget constraints are independent. Both are checked at every step:
 
-```python
+<CodeGroup>
+
+```python Python
 with cascadeflow.run(budget=0.50, compliance="gdpr") as session:
     # Must stay within budget AND use only GDPR-approved models
     result = await agent.run("Analyze EU customer feedback")
 ```
 
-## Custom Allowlists
+```typescript TypeScript
+await run({ budget: 0.50, compliance: 'regulated' }, async () => {
+  await agent.run('Analyze regulated customer feedback');
+});
+```
 
-The built-in allowlists cover common regulations. For custom requirements, set compliance at the integration level or use the `HarnessConfig` directly:
+</CodeGroup>
+
+## Custom Policies
+
+The harness APIs select built-in profiles by name. They do not currently accept custom model allowlists. For custom requirements, validate the selected model in your integration before sending the request.
 
 ```python
-config = HarnessConfig(
-    mode="enforce",
-    compliance="strict",  # Only gpt-4o
-)
-cascadeflow.init(config=config)
+approved_models = {"my-approved-deployment"}
+if selected_model not in approved_models:
+    raise PermissionError("Model is not approved")
 ```
 
 <Tip>

--- a/docs-site/harness/decision-trace.mdx
+++ b/docs-site/harness/decision-trace.mdx
@@ -9,19 +9,24 @@ Every harness decision produces a trace record. Traces provide a full audit trai
 
 Each trace record contains:
 
-| Field | Type | Description |
-|---|---|---|
-| `action` | string | `"allow"`, `"switch_model"`, `"deny_tool"`, or `"stop"` |
-| `reason` | string | Human-readable explanation of the decision |
-| `model` | string | Model name used for the call |
-| `step` | int | Step number in the run (1-indexed) |
-| `cost_total` | float | Cumulative cost in USD at this step |
-| `budget_state` | string | `"ok"`, `"warning"`, or `"exceeded"` |
-| `applied` | bool | `true` if the action was enforced, `false` in observe mode |
+| Python | TypeScript | Type | Description |
+|---|---|---|---|
+| `action` | `action` | string | `"allow"`, `"switch_model"`, `"deny_tool"`, or `"stop"` |
+| `reason` | `reason` | string | Machine-readable decision reason |
+| `model` | `model` | string | Model selected for the call |
+| `step` | `step` | integer | Step number in the run |
+| `cost_total` | `costTotal` | number | Cumulative cost in USD |
+| `latency_used_ms` | `latencyUsedMs` | number | Cumulative measured latency |
+| `energy_used` | `energyUsed` | number | Cumulative energy units |
+| `budget_state` | `budgetState` | object | Maximum and remaining budget |
+| `applied` | `applied` | boolean | Whether the decision changed execution |
+| `decision_mode` | `decisionMode` | string | Mode used to calculate the decision |
 
 ## Accessing Traces
 
-```python
+<CodeGroup>
+
+```python Python
 import cascadeflow
 
 cascadeflow.init(mode="observe")
@@ -31,23 +36,41 @@ with cascadeflow.run(budget=0.50) as session:
 
     # Full decision trace
     for record in session.trace():
-        print(f"Step {record['step']}: {record['action']} — {record['reason']}")
+        print(f"Step {record['step']}: {record['action']}: {record['reason']}")
         print(f"  Model: {record['model']}, Cost: ${record['cost_total']:.4f}")
-        print(f"  Budget: {record['budget_state']}, Applied: {record['applied']}")
+        print(f"  Remaining: {record['budget_state']['remaining']}, Applied: {record['applied']}")
 ```
+
+```typescript TypeScript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'observe' });
+
+await run({ budget: 0.50 }, async (session) => {
+  await agent.run('Research this topic');
+
+  for (const record of session.trace()) {
+    console.log(`Step ${record.step}: ${record.action}: ${record.reason}`);
+    console.log(`  Model: ${record.model}, Cost: $${record.costTotal.toFixed(4)}`);
+    console.log(`  Remaining: ${record.budgetState.remaining}, Applied: ${record.applied}`);
+  }
+});
+```
+
+</CodeGroup>
 
 Example output:
 
 ```
-Step 1: allow — budget ok, model compliant
+Step 1: allow: observe
   Model: gpt-4o-mini, Cost: $0.0003
-  Budget: ok, Applied: false
-Step 2: allow — budget ok, model compliant
+  Remaining: 0.4997, Applied: false
+Step 2: allow: observe
   Model: gpt-4o-mini, Cost: $0.0007
-  Budget: ok, Applied: false
-Step 3: switch_model — budget pressure, routing to cheaper model
+  Remaining: 0.4993, Applied: false
+Step 3: switch_model: budget_pressure
   Model: gpt-4o, Cost: $0.0032
-  Budget: warning, Applied: false
+  Remaining: 0.4968, Applied: false
 ```
 
 ## Observe vs Enforce
@@ -87,17 +110,33 @@ cb_manager = get_harness_callback_manager()
 
 In addition to per-step traces, `session.summary()` provides aggregate metrics:
 
-```python
+<CodeGroup>
+
+```python Python
 summary = session.summary()
 # {
-#     "cost_total": 0.0032,
-#     "steps": 3,
+#     "cost": 0.0032,
+#     "step_count": 3,
 #     "tool_calls": 1,
-#     "latency_total_ms": 1250.0,
+#     "latency_used_ms": 1250.0,
 #     "energy_used": 45.2,
 #     "budget_remaining": 0.4968,
 # }
 ```
+
+```typescript TypeScript
+const summary = session.summary();
+// {
+//   cost: 0.0032,
+//   stepCount: 3,
+//   toolCalls: 1,
+//   latencyUsedMs: 1250,
+//   energyUsed: 45.2,
+//   budgetRemaining: 0.4968,
+// }
+```
+
+</CodeGroup>
 
 <Tip>
 **Examples on GitHub:** [examples/production_patterns.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/production_patterns.py) | [examples/enforcement/basic_enforcement.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/enforcement/basic_enforcement.py)

--- a/docs-site/harness/energy-tracking.mdx
+++ b/docs-site/harness/energy-tracking.mdx
@@ -13,7 +13,7 @@ energy_units = coefficient * (input_tokens + output_tokens * 1.5)
 
 Output tokens are weighted 1.5x because generation is more compute-intensive than prompt processing.
 
-## Energy Coefficients
+## Python Energy Coefficients
 
 | Model | Coefficient | Relative Cost |
 |---|---|---|
@@ -36,11 +36,31 @@ Output tokens are weighted 1.5x because generation is more compute-intensive tha
 | claude-opus-4.5 | 1.80 | Very high |
 | o1 | 2.00 | Highest |
 
+## TypeScript Energy Coefficients
+
+| Model | Coefficient |
+|---|---:|
+| gpt-5 | 1.15 |
+| gpt-5-mini | 0.72 |
+| gpt-5-nano | 0.45 |
+| gpt-4o | 1.00 |
+| gpt-4o-mini | 0.55 |
+| o1 | 1.25 |
+| o1-mini | 0.85 |
+| o3-mini | 0.75 |
+| Claude Opus 4.5 | 1.20 |
+| Claude Sonnet 4.5 | 0.95 |
+| Claude Haiku 4.5 | 0.70 |
+
+Unknown TypeScript models use a coefficient of `0.9`.
+
 ## Energy Caps
 
 Set a maximum energy budget for a run:
 
-```python
+<CodeGroup>
+
+```python Python
 import cascadeflow
 
 cascadeflow.init(mode="enforce")
@@ -52,6 +72,21 @@ with cascadeflow.run(max_energy=100.0) as session:
     print(f"Energy used: {summary['energy_used']:.1f} units")
 ```
 
+```typescript TypeScript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+
+await run({ maxEnergy: 100 }, async (session) => {
+  await agent.run('Process this large dataset');
+
+  const summary = session.summary();
+  console.log(`Energy used: ${summary.energyUsed.toFixed(1)} units`);
+});
+```
+
+</CodeGroup>
+
 When energy exceeds the cap:
 - In `observe` mode: logged but not enforced
 - In `enforce` mode: execution stops with `action: "stop"`
@@ -60,7 +95,9 @@ When energy exceeds the cap:
 
 Include energy in KPI weights for carbon-aware routing:
 
-```python
+<CodeGroup>
+
+```python Python
 with cascadeflow.run(
     kpi_weights={"quality": 0.4, "cost": 0.3, "energy": 0.3}
 ) as session:
@@ -68,7 +105,17 @@ with cascadeflow.run(
     result = await agent.run("Summarize this article")
 ```
 
-## Pricing Table
+```typescript TypeScript
+await run({
+  kpiWeights: { quality: 0.4, cost: 0.3, energy: 0.3 },
+}, async () => {
+  await agent.run('Summarize this article');
+});
+```
+
+</CodeGroup>
+
+## Python Pricing Table
 
 Full pricing for all 18 supported models (USD per 1M tokens):
 
@@ -95,6 +142,8 @@ Full pricing for all 18 supported models (USD per 1M tokens):
 | gemini-2.0-flash | $0.10 | $0.40 |
 | gemini-1.5-flash | $0.075 | $0.30 |
 | gemini-1.5-pro | $1.25 | $5.00 |
+
+The TypeScript harness uses its own versioned pricing table for OpenAI and Anthropic models. See the package source when an exact coefficient is required for an audit.
 
 <Tip>
 **Example walkthrough:** [KPI-Weighted Routing (energy profile)](/examples/kpi-weighted-routing) | **GitHub:** [examples/cost_tracking.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/cost_tracking.py)

--- a/docs-site/harness/kpi-optimization.mdx
+++ b/docs-site/harness/kpi-optimization.mdx
@@ -16,7 +16,9 @@ The harness scores each model decision against configurable KPI weights. This le
 
 ## Configuration
 
-```python
+<CodeGroup>
+
+```python Python
 import cascadeflow
 
 cascadeflow.init(mode="enforce")
@@ -28,9 +30,23 @@ with cascadeflow.run(
     result = await agent.run("Analyze this legal document")
 ```
 
+```typescript TypeScript
+import { init, run } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+
+await run({
+  kpiWeights: { quality: 0.6, cost: 0.3, latency: 0.1 },
+}, async () => {
+  await agent.run('Analyze this legal document');
+});
+```
+
+</CodeGroup>
+
 ### Weights
 
-Weights are relative — they don't need to sum to 1.0 (they are normalized internally). They control the relative importance of each dimension in the composite score.
+Weights are relative. They do not need to sum to 1.0 because they are normalized internally. They control the relative importance of each dimension in the composite score.
 
 ```python
 # Quality-first (premium workload)
@@ -45,7 +61,7 @@ kpi_weights = {"quality": 0.4, "cost": 0.3, "latency": 0.2, "energy": 0.1}
 
 ### Targets
 
-Targets set minimum acceptable values. If a model's score for a dimension falls below the target, it is penalized in the composite score.
+Targets are retained in the run context as policy metadata. Current built-in routing decisions use KPI weights, not KPI targets.
 
 ```python
 kpi_targets = {
@@ -84,7 +100,9 @@ Built-in quality priors for common models (OpenAI):
 
 Different agents can have different priorities:
 
-```python
+<CodeGroup>
+
+```python Python
 @cascadeflow.agent(
     budget=0.50,
     kpi_weights={"quality": 0.8, "cost": 0.2}
@@ -99,6 +117,26 @@ async def quality_agent(query: str):
 async def budget_agent(query: str):
     return await llm.complete(query)
 ```
+
+```typescript TypeScript
+import { harnessAgent } from '@cascadeflow/core';
+
+const qualityAgent = harnessAgent({
+  budget: 0.50,
+  kpiWeights: { quality: 0.8, cost: 0.2 },
+})(async (query: string) => llm.complete(query));
+
+const budgetAgent = harnessAgent({
+  budget: 0.10,
+  kpiWeights: { cost: 0.8, quality: 0.2 },
+})(async (query: string) => llm.complete(query));
+```
+
+</CodeGroup>
+
+<Note>
+Agent policy metadata does not create a run automatically. Use `run()` around the agent execution when enforcement is required.
+</Note>
 
 <Tip>
 **Example walkthrough:** [KPI-Weighted Routing](/examples/kpi-weighted-routing) | **GitHub:** [examples/cost_tracking.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/cost_tracking.py) | [examples/semantic_quality_domain_detection.py](https://github.com/lemony-ai/cascadeflow/blob/main/examples/semantic_quality_domain_detection.py)

--- a/docs-site/harness/modes.mdx
+++ b/docs-site/harness/modes.mdx
@@ -11,9 +11,19 @@ cascadeflow operates in one of three modes, set at initialization.
 
 No tracking, no enforcement. The harness is completely disabled. This is the default.
 
-```python
+<CodeGroup>
+
+```python Python
 cascadeflow.init(mode="off")
 ```
+
+```typescript TypeScript
+import { init } from '@cascadeflow/core';
+
+init({ mode: 'off' });
+```
+
+</CodeGroup>
 
 ### `observe`
 
@@ -26,15 +36,9 @@ cascadeflow.init(mode="observe")
 ```
 
 ```typescript TypeScript
-import { CascadeAgent } from '@cascadeflow/core';
+import { init } from '@cascadeflow/core';
 
-// TypeScript uses CascadeAgent with quality config for observe-like behavior
-const agent = new CascadeAgent({
-  models: [
-    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.000375 },
-    { name: 'gpt-4o', provider: 'openai', cost: 0.00625 },
-  ],
-});
+init({ mode: 'observe' });
 ```
 
 </CodeGroup>
@@ -48,9 +52,19 @@ Use `observe` for:
 
 Track all metrics and enforce constraints. When a hard cap is hit (budget, tool calls, latency, energy) or a compliance violation is detected, the harness takes action: `stop`, `deny_tool`, or `switch_model`.
 
-```python
+<CodeGroup>
+
+```python Python
 cascadeflow.init(mode="enforce")
 ```
+
+```typescript TypeScript
+import { init } from '@cascadeflow/core';
+
+init({ mode: 'enforce' });
+```
+
+</CodeGroup>
 
 Use `enforce` when:
 - You have validated metrics in `observe` mode
@@ -75,6 +89,13 @@ import os
 # Environment-driven mode selection
 mode = os.getenv("CASCADEFLOW_MODE", "observe")
 cascadeflow.init(mode=mode)
+```
+
+```typescript TypeScript
+import { init } from '@cascadeflow/core';
+
+const mode = process.env.CASCADEFLOW_MODE ?? 'observe';
+init({ mode: mode as 'off' | 'observe' | 'enforce' });
 ```
 
 ## Mode Behavior Matrix

--- a/docs-site/harness/overview.mdx
+++ b/docs-site/harness/overview.mdx
@@ -18,9 +18,11 @@ The cascadeflow harness is an in-process intelligence layer that wraps AI agent 
 
 ## HarnessConfig
 
-All harness behavior is configured through a single dataclass:
+All harness behavior is configured through one object.
 
-```python
+<CodeGroup>
+
+```python Python
 from cascadeflow import HarnessConfig
 
 config = HarnessConfig(
@@ -39,6 +41,27 @@ config = HarnessConfig(
     compliance="gdpr",                 # "gdpr" | "hipaa" | "pci" | "strict" | None
 )
 ```
+
+```typescript TypeScript
+import type { HarnessConfig } from '@cascadeflow/core';
+
+const config: HarnessConfig = {
+  mode: 'enforce',
+  verbose: false,
+  budget: 0.50,
+  maxToolCalls: 10,
+  maxLatencyMs: 5000,
+  maxEnergy: 100,
+  kpiWeights: {
+    quality: 0.6,
+    cost: 0.3,
+    latency: 0.1,
+  },
+  compliance: 'regulated',
+};
+```
+
+</CodeGroup>
 
 ## Activation
 
@@ -62,21 +85,18 @@ async def my_agent(query: str):
 ```
 
 ```typescript TypeScript
-import { CascadeAgent } from '@cascadeflow/core';
+import { harnessAgent, init, run } from '@cascadeflow/core';
 
-const agent = new CascadeAgent({
-  models: [
-    { name: 'gpt-4o-mini', provider: 'openai', cost: 0.000375 },
-    { name: 'gpt-4o', provider: 'openai', cost: 0.00625 },
-  ],
-  quality: {
-    threshold: 0.8,
-    useSemanticValidation: true,
-  },
+init({ mode: 'observe' });
+
+await run({ budget: 0.50, maxToolCalls: 10 }, async (session) => {
+  await agent.run('Analyze this data');
+  console.log(session.summary());
 });
 
-const result = await agent.run('Analyze this data');
-console.log(`Model: ${result.modelUsed}, Cost: $${result.totalCost}`);
+const myAgent = harnessAgent({ budget: 0.20, compliance: 'regulated' })(
+  async (query: string) => agent.run(query),
+);
 ```
 
 </CodeGroup>
@@ -86,12 +106,12 @@ console.log(`Model: ${result.modelUsed}, Cost: $${result.totalCost}`);
 For each LLM call or tool execution:
 
 1. **Record** model, step number, cumulative cost, latency, energy
-2. **Check compliance** — is the model in the allowlist for the configured regulation?
-3. **Check hard caps** — budget, tool calls, latency, energy
-4. **Score KPI dimensions** — quality, cost, latency, energy weighted by `kpi_weights`
-5. **Decide action** — `allow`, `switch_model`, `deny_tool`, or `stop`
-6. **Enforce or log** — enforce in `enforce` mode, log only in `observe` mode
-7. **Append trace** — full decision record for auditability
+2. **Check compliance**: Is the model in the configured allowlist?
+3. **Check hard caps**: Budget, tool calls, latency, and energy.
+4. **Score KPI dimensions**: Quality, cost, latency, and energy weighted by `kpi_weights` or `kpiWeights`.
+5. **Decide action**: `allow`, `switch_model`, `deny_tool`, or `stop`.
+6. **Enforce or log**: Enforce in `enforce` mode, log only in `observe` mode.
+7. **Append trace**: Record the full decision for auditing.
 
 ## Supported Models
 
@@ -100,5 +120,5 @@ The harness includes a built-in pricing table for 18 models across OpenAI, Anthr
 See [Energy Tracking](/harness/energy-tracking) for the full pricing and energy coefficients table.
 
 <Tip>
-**Getting started:** [Agent Harness](/get-started/agent-harness) | [Agent Loop](/get-started/agent-loop) | **API reference:** [HarnessConfig](/api-reference/python/harness-config)
+**Getting started:** [Agent Harness](/get-started/agent-harness) | [Agent Loop](/get-started/agent-loop) | **Python API:** [HarnessConfig](/api-reference/python/harness-config) | **TypeScript API:** [Harness](/api-reference/typescript/harness)
 </Tip>

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -118,12 +118,12 @@ Every agent step is scored across six dimensions simultaneously:
     How cascadeflow operates inside multi-step agent execution.
   </Card>
   <Card title="Examples" icon="code" href="/examples/catalog">
-    42+ Python and 33+ TypeScript examples on GitHub.
+    51+ Python and 47+ TypeScript examples on GitHub.
   </Card>
   <Card title="Integrations" icon="puzzle-piece" href="/integrations/overview">
     LangChain, OpenAI Agents, CrewAI, Google ADK, n8n, Vercel AI, Hermes Agent.
   </Card>
-  <Card title="API Reference" icon="book" href="/api-reference/python/init">
+  <Card title="API Reference" icon="book" href="/api-reference/typescript/overview">
     Full Python and TypeScript API documentation.
   </Card>
   <Card title="For Coding Agents" icon="robot" href="/for-coding-agents">

--- a/docs-site/integrations/vercel-ai.mdx
+++ b/docs-site/integrations/vercel-ai.mdx
@@ -54,7 +54,7 @@ export const POST = handler;
 
 ## Multi-Turn Chat
 
-```typescript
+```tsx
 import { useChat } from 'ai/react';
 
 export default function Chat() {
@@ -82,8 +82,11 @@ Override cascade behavior per request (protected by shared secret):
 ```typescript
 const handler = createChatHandler(agent, {
   protocol: 'data',
-  allowOverrides: ['forceDirect', 'maxSteps'],
-  overrideSecret: process.env.OVERRIDE_SECRET,
+  requestOverrides: {
+    enabled: true,
+    allowedFields: ['forceDirect', 'maxSteps'],
+    secret: process.env.OVERRIDE_SECRET,
+  },
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "turbo run test",
     "lint": "turbo run lint",
     "clean": "turbo run clean",
+    "docs:check-typescript": "pnpm --filter @cascadeflow/core exec node ../../scripts/check-docs-typescript.mjs",
     "verify:npm:pack": "node scripts/verify-npm-packages.mjs"
   },
   "devDependencies": {

--- a/scripts/check-docs-typescript.mjs
+++ b/scripts/check-docs-typescript.mjs
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '..');
+const docsRoot = path.join(repositoryRoot, 'docs-site');
+const requireFromCore = createRequire(
+  path.join(repositoryRoot, 'packages', 'core', 'package.json'),
+);
+const ts = requireFromCore('typescript');
+
+function listMdxFiles(directory) {
+  const files = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listMdxFiles(target));
+    } else if (entry.isFile() && entry.name.endsWith('.mdx')) {
+      files.push(target);
+    }
+  }
+
+  return files;
+}
+
+function lineNumberAt(source, offset) {
+  return source.slice(0, offset).split(/\r?\n/).length;
+}
+
+const fencePattern = /```(typescript|tsx)(?: [^\n]*)?\r?\n([\s\S]*?)```/g;
+const failures = [];
+let checkedBlocks = 0;
+
+for (const file of listMdxFiles(docsRoot)) {
+  const source = fs.readFileSync(file, 'utf8');
+  let match;
+
+  while ((match = fencePattern.exec(source)) !== null) {
+    checkedBlocks += 1;
+    const language = match[1];
+    const code = match[2];
+    const blockStartLine = lineNumberAt(source, match.index) + 1;
+    const output = ts.transpileModule(code, {
+      compilerOptions: {
+        jsx: ts.JsxEmit.ReactJSX,
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2020,
+      },
+      fileName: `${file}.${language === 'tsx' ? 'tsx' : 'ts'}`,
+      reportDiagnostics: true,
+    });
+
+    for (const diagnostic of output.diagnostics ?? []) {
+      if (diagnostic.category !== ts.DiagnosticCategory.Error) {
+        continue;
+      }
+
+      let diagnosticLine = blockStartLine;
+      if (diagnostic.file && diagnostic.start !== undefined) {
+        const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        diagnosticLine += position.line;
+      }
+
+      const relativeFile = path.relative(repositoryRoot, file);
+      const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+      failures.push(`${relativeFile}:${diagnosticLine}: ${message}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
+  process.exitCode = 1;
+} else {
+  console.log(`Checked ${checkedBlocks} TypeScript and TSX documentation blocks.`);
+}


### PR DESCRIPTION
## Summary

- document the TypeScript cascade, harness, providers, tools, results, and quality routing APIs
- correct TypeScript examples across getting-started, harness, streaming, LangChain, and Vercel AI pages
- add TypeScript feature-parity guidance and navigation
- compile all TypeScript and TSX documentation snippets in CI

## Validation

- 1,334 Python tests passed, with 34 skipped and 59 deselected
- TypeScript core and n8n tests passed
- TypeScript builds, lint, type checks, examples, and npm package integrity passed
- Black, Ruff, and mypy passed
- 95 TypeScript and TSX documentation blocks compiled successfully