### PR TITLE
fix(n8n): pass connected tools to models and use core 1.x memory API in CascadeFlow Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **n8n CascadeFlow Agent: tools were never offered to the models.** The agent collected the nodes connected to its Tools port only to execute tool calls, but invoked the drafter, verifier and domain models without passing the tool definitions, so no model could ever request a tool (models answered with "shall I run the tool?" instead). The executor now forwards the connected tools as the LangChain `tools` call option on every model call; caller-provided `tools` still win.
+- **n8n CascadeFlow Agent: connected memory crashed on n8n 2.x.** Persisting the turn used `chatHistory.addUserMessage` / `addAIChatMessage`, which no longer exist in `@langchain/core` 1.x ("addAIChatMessage is not a function"). The node now writes through `chatHistory.addMessage` with `HumanMessage` / `AIMessage`, which works on core 0.3 and 1.x.
+
 ## [1.0.0] - 2026-03-07
 
 ### Added

--- a/packages/integrations/n8n/nodes/CascadeFlowAgent/CascadeFlowAgent.node.ts
+++ b/packages/integrations/n8n/nodes/CascadeFlowAgent/CascadeFlowAgent.node.ts
@@ -56,9 +56,25 @@ export interface ToolLike {
 interface ChatMemoryLike {
   chatHistory: {
     getMessages(): Promise<BaseMessage[]>;
-    addUserMessage(message: string): Promise<void>;
-    addAIChatMessage(message: string): Promise<void>;
+    addMessage(message: BaseMessage): Promise<void>;
   };
+}
+
+/**
+ * Persist one user/assistant turn to a connected n8n memory node.
+ *
+ * Uses `chatHistory.addMessage`, which exists in @langchain/core 0.3 and 1.x.
+ * The older `addUserMessage`/`addAIChatMessage` helpers were removed in core 1.x
+ * (shipped by n8n 2.x) and crash the node with "addAIChatMessage is not a function".
+ */
+export async function persistTurnToMemory(
+  memory: ChatMemoryLike | null | undefined,
+  userText: string,
+  assistantText: string,
+): Promise<void> {
+  if (!memory) return;
+  await memory.chatHistory.addMessage(new HumanMessage(userText));
+  await memory.chatHistory.addMessage(new AIMessage(assistantText));
 }
 
 export class CascadeFlowAgentExecutor {
@@ -291,8 +307,23 @@ export class CascadeFlowAgentExecutor {
     };
   }
 
+  /**
+   * Merge the connected tools into the model call options.
+   *
+   * The models only know about tools that are passed on the call (LangChain
+   * `tools` call option, what `bindTools` does under the hood). Without this the
+   * agent collects tools for execution but no model can ever request one.
+   * Caller-provided `options.tools` win.
+   */
+  private withTools(options?: any): any {
+    if (this.toolMap.size === 0) return options;
+    if (options && options.tools !== undefined) return options;
+    return { ...(options ?? {}), tools: Array.from(this.toolMap.values()) };
+  }
+
   async invoke(input: any, options?: any): Promise<any> {
     const messages = this.normalizeMessages(input);
+    options = this.withTools(options);
     const trace: any[] = [];
     let currentMessages = [...messages];
     let finalMessage: BaseMessage | null = null;
@@ -1070,10 +1101,7 @@ export class CascadeFlowAgent implements INodeType {
       const result = await agentExecutor.invoke(messages);
 
       // Persist to memory
-      if (memory) {
-        await memory.chatHistory.addUserMessage(text);
-        await memory.chatHistory.addAIChatMessage(result.output);
-      }
+      await persistTurnToMemory(memory, text, result.output);
 
       // Extract cascadeflow metadata from response
       const responseMetadata = result.message?.response_metadata ?? {};

--- a/packages/integrations/n8n/nodes/CascadeFlowAgent/__tests__/cascadeflow-agent-executor.test.ts
+++ b/packages/integrations/n8n/nodes/CascadeFlowAgent/__tests__/cascadeflow-agent-executor.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { AIMessage, SystemMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
 
-import { CascadeFlowAgentExecutor } from '../CascadeFlowAgent.node';
+import { CascadeFlowAgentExecutor, persistTurnToMemory } from '../CascadeFlowAgent.node';
 
 describe('CascadeFlowAgentExecutor', () => {
   it('normalizes plain role/content objects and preserves system prompts', async () => {
@@ -111,5 +111,115 @@ describe('CascadeFlowAgentExecutor', () => {
     expect(verifierCalled).toBe(1);
     expect(result.output).toBe('verifier');
   });
+
+  it('passes the connected tools to the cascade model so models can emit tool calls', async () => {
+    const tool = {
+      name: 'echo',
+      description: 'echoes its input',
+      invoke: async (args: any) => ({ echoed: args }),
+    };
+
+    const invokeOptions: any[] = [];
+    const verifierOptions: any[] = [];
+    let call = 0;
+    const cascadeModel = {
+      invoke: async (_messages: any[], options?: any) => {
+        invokeOptions.push(options);
+        call += 1;
+        if (call === 1) {
+          const msg = new AIMessage('calling tool');
+          (msg as any).additional_kwargs = {
+            tool_calls: [{ id: 't1', function: { name: 'echo', arguments: '{}' } }],
+          };
+          return msg;
+        }
+        return new AIMessage('done');
+      },
+      invokeVerifierDirect: async (_messages: any[], options?: any) => {
+        verifierOptions.push(options);
+        return new AIMessage('verifier');
+      },
+      stream: async function* () {
+        yield new AIMessage('stream');
+      },
+    } as any;
+
+    const exec = new CascadeFlowAgentExecutor(
+      cascadeModel,
+      [tool as any],
+      [{ toolName: 'echo', routing: 'verifier' }],
+      3
+    );
+    await exec.invoke('hi', { signal: 'keep-me' });
+
+    expect(invokeOptions[0]).toMatchObject({ signal: 'keep-me' });
+    expect(invokeOptions[0].tools).toEqual([tool]);
+    expect(verifierOptions[0].tools).toEqual([tool]);
+  });
+
+  it('does not add a tools option when no tools are connected', async () => {
+    let captured: any = 'unset';
+    const cascadeModel = {
+      invoke: async (_messages: any[], options?: any) => {
+        captured = options;
+        return new AIMessage('ok');
+      },
+      invokeVerifierDirect: async () => new AIMessage('verifier'),
+      stream: async function* () {
+        yield new AIMessage('stream');
+      },
+    } as any;
+
+    const exec = new CascadeFlowAgentExecutor(cascadeModel, [], [], 3);
+    await exec.invoke('hi');
+
+    expect(captured).toBeUndefined();
+  });
+
+  it('keeps caller-provided tools instead of overriding them', async () => {
+    const connected = { name: 'echo', invoke: async () => 'x' };
+    const override = { name: 'other', invoke: async () => 'y' };
+    let captured: any;
+    const cascadeModel = {
+      invoke: async (_messages: any[], options?: any) => {
+        captured = options;
+        return new AIMessage('ok');
+      },
+      invokeVerifierDirect: async () => new AIMessage('verifier'),
+      stream: async function* () {
+        yield new AIMessage('stream');
+      },
+    } as any;
+
+    const exec = new CascadeFlowAgentExecutor(cascadeModel, [connected as any], [], 3);
+    await exec.invoke('hi', { tools: [override] });
+
+    expect(captured.tools).toEqual([override]);
+  });
 });
 
+describe('persistTurnToMemory', () => {
+  it('writes the user and assistant turn through addMessage (LangChain core 1.x API)', async () => {
+    const stored: any[] = [];
+    const memory = {
+      chatHistory: {
+        getMessages: async () => [],
+        addMessage: async (message: any) => {
+          stored.push(message);
+        },
+      },
+    };
+
+    await persistTurnToMemory(memory as any, 'hello', 'hi there');
+
+    expect(stored).toHaveLength(2);
+    expect(stored[0]).toBeInstanceOf(HumanMessage);
+    expect(stored[0].content).toBe('hello');
+    expect(stored[1]).toBeInstanceOf(AIMessage);
+    expect(stored[1].content).toBe('hi there');
+  });
+
+  it('is a no-op without a memory node', async () => {
+    await expect(persistTurnToMemory(null, 'hello', 'hi')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Two defects in the n8n **CascadeFlow Agent** node (`@cascadeflow/n8n-nodes-cascadeflow`, present since #134), found while preparing a demo on n8n 2.4.6:

1. **Tools are never offered to the models.** `execute()` reads the nodes on the Tools port and hands them to `CascadeFlowAgentExecutor`, but the executor only uses them to *run* tool calls. The drafter, verifier and domain models are invoked without the tool definitions, so no model can ever request a tool. In practice a prompt like "what is the weather in X" ends with the model answering "shall I run the Weather tool?".
2. **A connected memory node crashes the agent on n8n 2.x.** Persisting the turn calls `chatHistory.addUserMessage` / `addAIChatMessage`, which were removed in `@langchain/core` 1.x (`addAIChatMessage is not a function`). Our peer range allows core 1.x.

Neither was caught by tests: the executor test mocks a cascade model that already returns `tool_calls`, so tool binding was never exercised.

## Fix

- `CascadeFlowAgentExecutor.withTools()` merges the connected tools into the model call options (LangChain `tools` call option, the same thing `bindTools` sets) for `invoke`, `invokeVerifierDirect` and `stream`. No tools connected: options are passed through untouched. Caller-provided `options.tools` win.
- New exported `persistTurnToMemory()` writes the turn via `chatHistory.addMessage(new HumanMessage(...))` / `addMessage(new AIMessage(...))`, available in core 0.3 and 1.x. `ChatMemoryLike` updated accordingly.
- CHANGELOG: Unreleased / Fixed entries.

## Tests

- New executor tests: tools forwarded to `invoke` and `invokeVerifierDirect`, no `tools` key without connected tools, caller override kept.
- New `persistTurnToMemory` tests (core 1.x style history, and null memory).
- `vitest run` in `packages/integrations/n8n`: 55 passed. `tsc --noEmit` and eslint clean for the changed files. `npm run build` bundles fine.
- Verified end to end on n8n 2.4.6 with the equivalent change applied to the installed node: Calculator, Wikipedia and OpenWeatherMap tools are called by the drafter and verifier, and Window Buffer Memory works across turns.

Version is left at 1.3.0; bump separately when publishing.

https://claude.ai/code/session_018SnqMYYEDpG72ZGubKLtx6